### PR TITLE
[UCA-443] removed support to use swap memory, setting swappiness to zero

### DIFF
--- a/SwanSpawner/swanspawner/swandockerspawner.py
+++ b/SwanSpawner/swanspawner/swandockerspawner.py
@@ -106,6 +106,9 @@ class SwanDockerSpawner(define_SwanSpawner_from(SystemUserSpawner)):
             self.extra_host_config['port_bindings'] = {}
             self.extra_create_kwargs['ports'] = []
 
+            #disabling swap memory usage
+            self.extra_host_config['mem_swappiness'] = 0
+
             if self.lcg_rel_field not in self.user_options:
                 # session spawned via the API, in binder start notebook with jovyan user
                 self.extra_create_kwargs['working_dir'] = "/home/jovyan"


### PR DESCRIPTION
According to 
https://docs.docker.com/config/containers/resource_constraints/#--memory-swappiness-details

swappiness should be zero.

using docker inspect to the container  in swan-spare003,
I can see that the value changed from 

"MemorySwappiness": null,
to
"MemorySwappiness": 0

Cheers
Omar.