### PR TITLE
CERNHandlers: Show auth state to logged in user

### DIFF
--- a/CERNHandlers/cernhandlers/__init__.py
+++ b/CERNHandlers/cernhandlers/__init__.py
@@ -1,2 +1,3 @@
 from .spawn_handler import *
 from .error_handler import *
+from .userapi_handler import *

--- a/CERNHandlers/cernhandlers/userapi_handler.py
+++ b/CERNHandlers/cernhandlers/userapi_handler.py
@@ -1,0 +1,27 @@
+
+from jupyterhub.apihandlers.base import APIHandler
+from tornado import web
+import json
+
+
+class SelfAPIHandler(APIHandler):
+    """
+        Handler for the user api endpoint.
+        This allows us to force the visibility of the auth state
+
+
+        Return the authenticated user's model
+        Based on the authentication info. Acts as a 'whoami' for auth tokens.
+    """
+
+    async def get(self):
+        user = self.current_user
+        if user is None:
+            # whoami can be accessed via oauth token
+            user = self.get_current_user_oauth_token()
+        if user is None:
+            raise web.HTTPError(403)
+
+        model = self.user_model(user)
+        model['auth_state'] = await user.get_auth_state()
+        self.write(json.dumps(model))

--- a/scripts/start_jupyterhub.py
+++ b/scripts/start_jupyterhub.py
@@ -2,14 +2,16 @@
 
 import jupyterhub.handlers.pages as pages
 import jupyterhub.handlers.base as base
+import jupyterhub.apihandlers.users as users
 from jupyterhub.utils import url_path_join
 from jupyterhub import app
-from cernhandlers import SpawnHandler, ProxyErrorHandler
+from cernhandlers import SpawnHandler, ProxyErrorHandler, SelfAPIHandler
 import sys
 
 handlers_map = {
     pages.SpawnHandler: SpawnHandler,
-    pages.ProxyErrorHandler: ProxyErrorHandler
+    pages.ProxyErrorHandler: ProxyErrorHandler,
+    users.SelfAPIHandler: SelfAPIHandler
 }
 
 


### PR DESCRIPTION
Workaround to allow the oauthrefresher to retrieve the latest oauth token from JupyterHub.

The Jupyter Server Extension that retrieves the user oauth token from JupyterHub (renewed by the Authenticator), assumed that the auth state was visible to the user and it was possible to retrieve it via the API. But this only happens to admins and not to a normal user, thus invalidating our approach. With this change I force the auth state to be visible, even for normal users, while I wait for a clarification with upstream. Ofc others users will only be able to see their tokens and no one else's.

Related to swan-cern/jupyter-extensions#27