### PR TITLE
Add option to start session with jupyterlab

### DIFF
--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -39,6 +39,8 @@ def define_SwanSpawner_from(base_class):
 
         user_memory = 'memory'
 
+        use_jupyterlab_field = 'use-jupyterlab'
+
         spark_cluster_field = 'spark-cluster'
 
         options_form_config = Unicode(
@@ -90,6 +92,7 @@ def define_SwanSpawner_from(base_class):
             options[self.spark_cluster_field]   = formdata[self.spark_cluster_field][0] if self.spark_cluster_field in formdata.keys() else 'none'
             options[self.user_n_cores]          = int(formdata[self.user_n_cores][0])
             options[self.user_memory]           = formdata[self.user_memory][0] + 'G'
+            options[self.use_jupyterlab_field]  = formdata.get(self.use_jupyterlab_field, ['unchecked'])[0]
 
             self.offload = options[self.spark_cluster_field] != 'none'
 
@@ -139,6 +142,10 @@ def define_SwanSpawner_from(base_class):
                     USER_ID                = 1000,
                     NB_UID                 = 1000,
                     SERVER_HOSTNAME        = os.uname().nodename,
+                ))
+            if self.user_options[self.use_jupyterlab_field] == 'checked':
+                env.update(dict(
+                    SWAN_USE_JUPYTERLAB = 'true'
                 ))
 
             if self.extra_env:

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -202,4 +202,19 @@
     </div>
     </label>
     <select id="clusterOptions" name="spark-cluster"></select>
+    <br />
+    <label> User Interface <a href="#" onclick="toggle_visibility('userInterfaceDetails');"><span class='nbs'>more...</span></a></label>
+    <div style="display:none;" id="userInterfaceDetails">
+        <span class='nb'>The JupyterLab interface offers a more complete development environment for notebooks. Please let us know about any issues you encounter or any feedback you have.</span>
+    </div>
+    <div style="display: flex; align-items: center">
+      <input
+        id="use-jupyterlab"
+        type="checkbox"
+        name="use-jupyterlab"
+        value="checked"
+        style="display: inline; width: initial; margin: 0 8px 0 0"
+      />
+      <span> Try the new JupyterLab interface (experimental)</span>
+    </div>
 </div>


### PR DESCRIPTION
- Adds a checkbox to the options form html to start the session with jupyter lab
- The spawner sets an environment variable on the container which is read by the systemuser script to set `c.NotebookApp.default_url` ([in a separate PR to systemuser image](https://github.com/swan-cern/systemuser-image/pull/43))
![image](https://user-images.githubusercontent.com/6822941/134520286-600dd5e4-4411-4b37-bcca-0a3cb97b58df.png)



We need to merge this only after all the other jupyter extensions are merged as this will be visible to users.