### PR TITLE
Fix logout and pin oauthenticator version

### DIFF
--- a/KeyCloakAuthenticator/README.md
+++ b/KeyCloakAuthenticator/README.md
@@ -30,7 +30,9 @@ In your JupyterHub config file, set the authenticator and configure it:
 # Enable the authenticator
 c.JupyterHub.authenticator_class = 'keycloakauthenticator.KeyCloakAuthenticator'
 c.KeyCloakAuthenticator.username_key = 'preferred_username'
-c.KeyCloakAuthenticator.logout_redirect_uri = 'https://cern.ch/swan'
+
+# URL to redirect to after logout is complete with auth provider.
+c.KeyCloakAuthenticator.logout_redirect_url = 'https://cern.ch/swan'
 c.KeyCloakAuthenticator.oauth_callback_url = 'https://swan.cern.ch/hub/oauth_callback'
 
 # Specify the issuer url, to get all the endpoints automatically from .well-known/openid-configuration

--- a/KeyCloakAuthenticator/setup.py
+++ b/KeyCloakAuthenticator/setup.py
@@ -23,7 +23,7 @@ setup_args = dict(
     packages=setuptools.find_packages(),
     install_requires=[
         'jupyterhub',
-        'oauthenticator',
+        'oauthenticator==14.2.0',
         'PyJWT[crypto]>=2.0.0'
     ],
     zip_safe=False,


### PR DESCRIPTION
- Fixes failing logout on kubernetes and new puppet nodes
- Removes `KeyCloakLogoutHandler` in favor of `OAuthenticator.logout_redirect_url` which provides similar functionality
- Removes config `logout_redirect_uri` in favor of the upstream config above
- Pin OAuthenticator version

TODO This needs renaming `logout_redirect_uri` to `logout_redirect_url` in the chart values when updating the image in the chart