### PR TITLE
Authenticator improvements

### DIFF
--- a/KeyCloakAuthenticator/keycloakauthenticator/auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/auth.py
@@ -166,6 +166,8 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
                     jwk_data = await self.fetch(req, "fetching jwks")
                     self.public_key = RSAAlgorithm(RSAAlgorithm.SHA256).from_jwk(jwk_data['keys'][0])
                     self.log.info(f"aquired public key from {jwks_uri}")
+                else:
+                    self.public_key = None
 
                 self.configured = True
                 # All good, let's finish


### PR DESCRIPTION
Fixes #42 
Fixes #41 

This update re-uses the parent class fetch method to be able to disable the ssl check in a more maintainable and consistent way. At the same time, this client is asynchronous, which means JH won't block.

Took the opportunity to address an issue that might occur when the IDP is down and we need to restart JH. Without the IDP, JH would block/crash, preventing even logged in users from continue working. Now, it will retry every minute.
New users will see a 500 saying that the config is not ok. Logged in users might be required to re-login, but JH doesn't enforce it (maybe it should...) so they will be able to continue working even if the auth is down (which is an improvement). Once the IDP comes back, the logged in users might not even required to re-login, if their session state is still valid (since we have offline tokens, should be fine.. for EOS, though...).

Also realized that the renew would fail if there was no `public_key` attribute, which is the case if we disable the token validation.

@ebocchi can you please check that ssl disable works? (just set `tls_verify` to 0/False)
@krishnan-r @rccern can you confirm I didn't break anything?