### PR TITLE
Add a loading screen for login page.

### DIFF
--- a/SwanHub/swanhub/templates/login.html
+++ b/SwanHub/swanhub/templates/login.html
@@ -1,0 +1,36 @@
+{% extends "page.html" %}
+{% if announcement_login %}
+  {% set announcement = announcement_login %}
+{% endif %}
+
+{% block login_widget %}
+{% endblock %}
+
+{% block main %}
+
+{% block login %}
+<div class="container">
+  <div class="row">
+    <div class="swan-info">
+      <div id="swan-loader">
+        <div class="loader-circle">
+          <img src="{{ static_url('swan/logos/logo_swan_letters.png') }}">
+        </div>
+        <div class="loader-line-mask">
+          <div class="loader-line"></div>
+        </div>
+        <span class="text">Logging you in</span>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock login %}
+
+{% endblock %}
+
+{% block script %}
+{{super()}}
+<script type="text/javascript">
+  window.location.replace('{{authenticator_login_url}}');
+</script>
+{% endblock %}


### PR DESCRIPTION
This page shows a spinner and redirects from javascript to start the oauth process This prevents an unresponsive page when logins are slow.

- Requires Authenticator.auto_login to be disabled (https://github.com/swan-cern/swan-charts/pull/104)
- The only thing different here from puppet infrastructure is that the redirect URL does not include the hostname, as the hostname is not available (from the puppet templating)