### PR TITLE
Tornado queue & request_time as prometheus metrics

### DIFF
--- a/KeyCloakAuthenticator/keycloakauthenticator/auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/auth.py
@@ -242,7 +242,7 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
                     self.log.error("Could not obtain access token for {}".format(new_token))
                     
                 metric_exchange_tornado_request_time.labels("exchange_token_{}".format(new_token.replace("-","_"))).observe(response.request_time)
-                metric_exchange_queue_time.labels("exchange_token_{}".format(new_token.replace("-","_"))).observe(response.time_info.get('queue'))            
+                metric_exchange_tornado_queue_time.labels("exchange_token_{}".format(new_token.replace("-","_"))).observe(response.time_info.get('queue'))            
                 self.log.info('Exchanged {} token in {} seconds'.format(new_token, time.time() - start))
         return tokens
     

--- a/KeyCloakAuthenticator/keycloakauthenticator/auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/auth.py
@@ -21,9 +21,9 @@ from .metrics import (
     metric_authenticate, 
     metric_pre_spawn_start, 
     metric_exchange_tornado_request_time, 
-    metric_exchange_queue_time,
+    metric_exchange_tornado_queue_time,
     metric_refresh_tornado_request_time, 
-    metric_refresh_queue_time
+    metric_refresh_tornado_queue_time
 )
 
 # Use a login handler wrapper to ensure the configuration was loaded before redirecting the user
@@ -239,7 +239,7 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
                     response_body = json.loads(response.body.decode('utf8', 'replace'))
 
                 metric_exchange_tornado_request_time.labels("exchange_token_{}".format(new_token.replace("-","_"))).observe(response.request_time)
-                metric_exchange_queue_time.labels("exchange_token_{}".format(new_token.replace("-","_"))).observe(response.time_info.get('queue'))
+                metric_exchange_tornado_queue_time.labels("exchange_token_{}".format(new_token.replace("-","_"))).observe(response.time_info.get('queue'))
                 tokens[new_token] = response_body.get('access_token', None)
                 self.log.info('Exchanged {} token in {} seconds'.format(new_token, time.time() - start))
         return tokens
@@ -268,7 +268,7 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
                 response_body = json.loads(response.body.decode('utf8', 'replace'))
             
             metric_refresh_tornado_request_time.observe(response.request_time)
-            metric_refresh_queue_time.observe(response.time_info.get('queue'))
+            metric_refresh_tornado_queue_time.observe(response.time_info.get('queue'))
 
             self.log.info('Refresh token request completed in {} seconds'.format(time.time() - start))
             return (response_body.get('access_token', None), response_body.get('refresh_token', None))

--- a/KeyCloakAuthenticator/keycloakauthenticator/auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/auth.py
@@ -241,7 +241,7 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
                 if access_token is None:
                     self.log.error("Could not obtain access token for {}".format(new_token))
                     
-                metric_exchange_tornado_request_time.labels("exchange_token_{}".format(new_token.replace("-","_"))).observe(response.request_time)
+                metric_exchange_tornado_request_time.labels("exchange_token_{}".format(new_token.replace("-","_")), response.code).observe(response.request_time)
                 metric_exchange_tornado_queue_time.labels("exchange_token_{}".format(new_token.replace("-","_"))).observe(response.time_info.get('queue'))            
                 self.log.info('Exchanged {} token in {} seconds'.format(new_token, time.time() - start))
         return tokens
@@ -276,7 +276,7 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
             if refresh_t is None:
                self.log.error("Could not obtain refresh token for swan") 
             
-            metric_refresh_tornado_request_time.observe(response.request_time)
+            metric_refresh_tornado_request_time.labels("refresh_token",response.code).observe(response.request_time)
             metric_refresh_tornado_queue_time.observe(response.time_info.get('queue'))
             self.log.info('Refresh token request completed in {} seconds'.format(time.time() - start))
             return access_t, refresh_t

--- a/KeyCloakAuthenticator/keycloakauthenticator/metrics.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/metrics.py
@@ -46,7 +46,7 @@ _REQUEST_DURATION_SECONDS = Histogram(
 _TORNADO_REQUEST_DURATION_SECONDS = Histogram(
     "keycloak_authenticator_tornado_request_duration_seconds",
     "Histogram of durations of outgoing requests made by the KeyCloakAuthenticator as reported by tornado",
-    labelnames=["request"],
+    labelnames=["request", "code"],
     buckets=_buckets,
 )
 _TORNADO_QUEUE_DURATION_SECONDS = Histogram(
@@ -65,5 +65,5 @@ metric_refresh_token = _REQUEST_DURATION_SECONDS.labels("refresh_token")
 
 metric_exchange_tornado_request_time = _TORNADO_REQUEST_DURATION_SECONDS # Label 'request' set dynamically
 metric_exchange_tornado_queue_time = _TORNADO_QUEUE_DURATION_SECONDS # Label 'request' set dynamically
-metric_refresh_tornado_request_time = _TORNADO_REQUEST_DURATION_SECONDS.labels("refresh_token")
+metric_refresh_tornado_request_time = _TORNADO_REQUEST_DURATION_SECONDS # Label 'request' set dynamically
 metric_refresh_tornado_queue_time = _TORNADO_QUEUE_DURATION_SECONDS.labels("refresh_token")

--- a/KeyCloakAuthenticator/keycloakauthenticator/metrics.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/metrics.py
@@ -64,6 +64,6 @@ metric_exchange_token = _REQUEST_DURATION_SECONDS # Label 'request' set dynamica
 metric_refresh_token = _REQUEST_DURATION_SECONDS.labels("refresh_token")
 
 metric_exchange_tornado_request_time = _TORNADO_REQUEST_DURATION_SECONDS # Label 'request' set dynamically
-metric_exchange_queue_time = _TORNADO_QUEUE_DURATION_SECONDS # Label 'request' set dynamically
+metric_exchange_tornado_queue_time = _TORNADO_QUEUE_DURATION_SECONDS # Label 'request' set dynamically
 metric_refresh_tornado_request_time = _TORNADO_REQUEST_DURATION_SECONDS.labels("refresh_token")
-metric_refresh_queue_time = _TORNADO_QUEUE_DURATION_SECONDS.labels("refresh_token")
+metric_refresh_tornado_queue_time = _TORNADO_QUEUE_DURATION_SECONDS.labels("refresh_token")

--- a/KeyCloakAuthenticator/keycloakauthenticator/metrics.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/metrics.py
@@ -43,9 +43,27 @@ _REQUEST_DURATION_SECONDS = Histogram(
     buckets=_buckets,
 )
 
+_TORNADO_REQUEST_DURATION_SECONDS = Histogram(
+    "keycloak_authenticator_tornado_request_duration_seconds",
+    "Histogram of durations of outgoing requests made by the KeyCloakAuthenticator as reported by tornado",
+    labelnames=["request"],
+    buckets=_buckets,
+)
+_TORNADO_QUEUE_DURATION_SECONDS = Histogram(
+    "keycloak_authenticator_tornado_queue_duration_seconds",
+    "Histogram of durations of time spent in queue for requests made by the KeyCloakAuthenticator as reported by tornado",
+    labelnames=["request"],
+    buckets=_buckets,
+)
+
 metric_refresh_user = _METHOD_DURATION_SECONDS.labels("refresh_user")
 metric_authenticate = _METHOD_DURATION_SECONDS.labels("authenticate")
 metric_pre_spawn_start = _METHOD_DURATION_SECONDS.labels("pre_spawn_start")
 
-metric_exchange_token  = _REQUEST_DURATION_SECONDS # Label 'request' set dynamically
+metric_exchange_token = _REQUEST_DURATION_SECONDS # Label 'request' set dynamically
 metric_refresh_token = _REQUEST_DURATION_SECONDS.labels("refresh_token")
+
+metric_exchange_tornado_request_time = _TORNADO_REQUEST_DURATION_SECONDS # Label 'request' set dynamically
+metric_exchange_queue_time = _TORNADO_QUEUE_DURATION_SECONDS # Label 'request' set dynamically
+metric_refresh_tornado_request_time = _TORNADO_REQUEST_DURATION_SECONDS.labels("refresh_token")
+metric_refresh_queue_time = _TORNADO_QUEUE_DURATION_SECONDS.labels("refresh_token")

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -58,6 +58,7 @@ async def test_refresh_user(monkeypatch):
             })
         class MockResponse:
             def __init__(self):
+                self.code = 200
                 self.body = mock_response_body.encode('utf-8')
                 self.request_time = 0
                 self.time_info ={
@@ -127,6 +128,7 @@ async def test_refresh_user_with_expired_refresh_token(monkeypatch):
             })
         class MockResponse:
             def __init__(self):
+                self.code = 200
                 self.body = mock_response_body.encode('utf-8')
                 self.request_time = 0
                 self.time_info ={


### PR DESCRIPTION
- Add keycloak_authenticator_tornado_request_duration_seconds metric that measures request times reported by tornado

- Add keycloak_authenticator_tornado_queue_duration_seconds metric that measures time spent in queue for requests

- Log request failures for exchange or refresh requests