### PR TITLE
Parallelize token exchange requests

### DIFF
--- a/KeyCloakAuthenticator/keycloakauthenticator/metrics.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/metrics.py
@@ -60,7 +60,6 @@ metric_refresh_user = _METHOD_DURATION_SECONDS.labels("refresh_user")
 metric_authenticate = _METHOD_DURATION_SECONDS.labels("authenticate")
 metric_pre_spawn_start = _METHOD_DURATION_SECONDS.labels("pre_spawn_start")
 
-metric_exchange_token = _REQUEST_DURATION_SECONDS # Label 'request' set dynamically
 metric_refresh_token = _REQUEST_DURATION_SECONDS.labels("refresh_token")
 
 metric_exchange_tornado_request_time = _TORNADO_REQUEST_DURATION_SECONDS # Label 'request' set dynamically


### PR DESCRIPTION
At the time of committing, token exchange requests to CERN SSO can have a response time of many seconds (> 10). This commit schedules them in one go for asynchronous execution via `asyncio.gather`, instead of doing them in sequence.

Note that the maximum number of requests done via `self.fetch` that are in flight in a given moment is still limited by Tornado's `AsyncHTTPClient`'s `max_clients` setting.