### PR TITLE
Temporary fix for storing spawner user_options in the database

### DIFF
--- a/SwanSpawner/swanspawner/swankubespawner.py
+++ b/SwanSpawner/swanspawner/swankubespawner.py
@@ -45,3 +45,23 @@ class SwanKubeSpawner(define_SwanSpawner_from(KubeSpawner)):
             ))
 
         return env
+
+    # The state management methods below are a temporary fix to store `user_options`
+    # in the database, so that it is restored after a hub restart.
+    # To be removed when updating to JupyterHub 2.1.0 or higher, which stores
+    # `user_options` in the database by default:
+    # https://github.com/jupyterhub/jupyterhub/pull/3773
+    def get_state(self):
+        """Get the current state to save in the database"""
+        state = super().get_state()
+        if self.user_options:
+            state['user_options'] = self.user_options
+        self.log.debug("State to save for {} is: {}".format(self.user.name, state))
+        return state
+
+    def load_state(self, state):
+        """Load state from the database"""
+        super().load_state(state)
+        if 'user_options' in state:
+            self.user_options = state['user_options']
+        self.log.debug("State loaded for {} is {}".format(self.user.name, state))


### PR DESCRIPTION
The state management methods added by this commit are a temporary fix to store the user_options attribute in the database, so that it is restored after a hub restart. This is intended to fix an error in the post_stop_hook that cleans the Spark services, since that hook checks user_options to see if the user selected a Spark cluster; if the hub has restarted, those user_options are lost and the hook can't do its job.

To be removed when updating to JupyterHub 2.1.0 or higher, which has a fix:
https://github.com/jupyterhub/jupyterhub/pull/3773

The clear_state method is not defined here to clear user_options, since it is invoked when spawning a new user session and it would clear the options that the user specified in the form.