### PR TITLE
Log access token in case of exchange failure for debugging purposes

### DIFF
--- a/KeyCloakAuthenticator/keycloakauthenticator/auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/auth.py
@@ -370,8 +370,7 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
                     try:
                         auth_state['exchanged_tokens'] = await self._exchange_tokens(access_token)
                     except:
-                        self.log.error("Failed to exchange tokens during refresh, took %s seconds" % (time.time()-start), exc_info=True)
-
+                        self.log.error("Failed to exchange tokens during refresh, took %s seconds, access token %s" % (time.time()-start, access_token), exc_info=True)
                         return False
 
                     self.log.info('User %s oAuth tokens refreshed, took %s seconds' % (user.name, (time.time() - start)))


### PR DESCRIPTION
In the SWAN logs, we have observed that sporadically, for certain users, we are able to successfully complete a refresh request to the SSO for the SWAN access token, but when we use that token in the subsequent exchange requests, those fail.

This PR intends to help with the debugging of such issue by logging the user access token in case of exchange error to be able to provide it to the SSO team.