### PR TITLE
Offer the option to select the CERN HTCondor pool in the web form

### DIFF
--- a/SwanSpawner/swanspawner/swankubespawner.py
+++ b/SwanSpawner/swanspawner/swankubespawner.py
@@ -81,24 +81,26 @@ class SwanKubeSpawner(define_SwanSpawner_from(KubeSpawner)):
             except ApiException as e:
                 self.log.error('Error deleting secret {namespace}:{eos_secret_name}: {e}')
 
-            # Spark-related cleanup
-            spark_cluster = self.user_options[self.spark_cluster_field]
-            if spark_cluster and spark_cluster != 'none':
-                # Delete NodePort service opening ports for the user Spark processes
-                spark_ports_service = f'spark-ports-{username}'
-                self.log.info(f'Deleting service {namespace}:{spark_ports_service}')
+            # Cleanup for computing integrations (Spark, HTCondor)
+            clean_spark = self.user_options[self.spark_cluster_field] != 'none'
+            clean_condor = self.user_options[self.condor_pool] != 'none'
+            if clean_spark or clean_condor:
+                # Delete NodePort service opening ports for computing integrations
+                computing_ports_service = f'computing-ports-{username}'
+                self.log.info(f'Deleting service {namespace}:{computing_ports_service}')
                 try:
-                    await self.api.delete_namespaced_service(spark_ports_service, namespace)
+                    await self.api.delete_namespaced_service(computing_ports_service, namespace)
                 except ApiException as e:
-                    self.log.error('Error deleting service {namespace}:{spark_ports_service}: {e}')
+                    self.log.error('Error deleting service {namespace}:{computing_ports_service}: {e}')
 
-                # Delete Kubernetes secret with Hadoop delegation tokens
-                hadoop_secret_name = f'hadoop-tokens-{username}'
-                self.log.info(f'Deleting secret {namespace}:{hadoop_secret_name}')
-                try:
-                    await self.api.delete_namespaced_secret(hadoop_secret_name, namespace)
-                except ApiException as e:
-                    self.log.error('Error deleting secret {namespace}:{hadoop_secret_name}: {e}')
+                if clean_spark:
+                    # Delete Kubernetes secret with Hadoop delegation tokens
+                    hadoop_secret_name = f'hadoop-tokens-{username}'
+                    self.log.info(f'Deleting secret {namespace}:{hadoop_secret_name}')
+                    try:
+                        await self.api.delete_namespaced_secret(hadoop_secret_name, namespace)
+                    except ApiException as e:
+                        self.log.error('Error deleting secret {namespace}:{hadoop_secret_name}: {e}')
 
     def get_env(self):
         """ Set base environmental variables for swan jupyter docker image """

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -39,6 +39,8 @@ def define_SwanSpawner_from(base_class):
 
         spark_cluster_field = 'spark-cluster'
 
+        condor_pool = 'condor-pool'
+
         options_form_config = Unicode(
             config=True,
             help='Path to configuration file for options_form rendering.'
@@ -81,6 +83,7 @@ def define_SwanSpawner_from(base_class):
             options[self.platform_field]        = formdata[self.platform_field][0]
             options[self.user_script_env_field] = formdata[self.user_script_env_field][0]
             options[self.spark_cluster_field]   = formdata[self.spark_cluster_field][0] if self.spark_cluster_field in formdata.keys() else 'none'
+            options[self.condor_pool]           = formdata[self.condor_pool][0]
             options[self.user_n_cores]          = int(formdata[self.user_n_cores][0])
             options[self.user_memory]           = formdata[self.user_memory][0] + 'G'
 
@@ -128,6 +131,10 @@ def define_SwanSpawner_from(base_class):
                     NB_UID                 = 1000,
                     SERVER_HOSTNAME        = os.uname().nodename,
                 ))
+
+            # Enable configuration for CERN HTCondor pool
+            if self.user_options[self.condor_pool] != 'none':
+                env['CERN_HTCONDOR'] = 'true'
 
             return env
 

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -150,6 +150,23 @@
 
             selectCluster.add(selectClusterOption);
         }
+
+        // adjust condor option for lcg
+        var selectCondor = document.getElementById('condorOptions');
+        selectCondor.innerHTML = '';
+
+        for( var i = 0 ; i < lcgData.condor.length ; i++ ){
+            var lcgCondor = lcgData.condor[i];
+
+            var selectCondorOption = document.createElement("option");
+            selectCondorOption.value = lcgCondor.value;
+            selectCondorOption.text = lcgCondor.text;
+            if (i === 0) {
+                selectCondorOption.selected = true;
+            }
+
+            selectCondor.add(selectCondorOption);
+        }
     }
 
     window.onload = adjust_form;
@@ -196,10 +213,18 @@
     </label>
     <select id="memoryOptions" name="memory"></select>
     <br>
+    <h2 for="computing-resources">External computing resources</h2>
     <label for="clusterOptions">Spark cluster <a href="#" onclick="toggle_visibility('sparkClusterDetails');"><span class='nbs'>more...</span></a>
     <div style="display:none;" id="sparkClusterDetails">
         <span class='nb'>Name of the Spark cluster to connect to from notebooks. See the <a target="_blank" href="https://hadoop-user-guide.web.cern.ch/">Hadoop User guide</a> and the <a target="_blank" href="https://sparktraining.web.cern.ch/">Spark training course</a></span>
     </div>
     </label>
     <select id="clusterOptions" name="spark-cluster"></select>
+    <br>
+    <label for="condorOptions">HTCondor pool <a href="#" onclick="toggle_visibility('condorDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="condorDetails">
+        <span class='nb'>Name of the HTCondor pool to use.</span>
+    </div>
+    </label>
+    <select id="condorOptions" name="condor-pool"></select>
 </div>


### PR DESCRIPTION
This makes it possible for users to select the CERN HTCondor pool in the SWAN web form, in the same way they now select Spark clusters.

Additionally, this PR modifies the stop method of the kubespawner to clean the k8s objects that were created when HTCondor was selected. Notice that now the service that opens ports is generic and is shared by Spark and HTCondor.