### PR TITLE
Allow to configure an extra URL for a CentOS7-based user image

### DIFF
--- a/SwanSpawner/swanspawner/swankubespawner.py
+++ b/SwanSpawner/swanspawner/swankubespawner.py
@@ -22,7 +22,8 @@ class SwanKubeSpawner(define_SwanSpawner_from(KubeSpawner)):
     )
 
     async def start(self):
-        """Perform the operations necessary for GPU support
+        """Perform extra configurations required for SWAN session spawning in
+        kubernetes.
         """
 
         if self._gpu_requested():

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -111,6 +111,7 @@ def define_SwanSpawner_from(base_class):
                     USER_ENV_SCRIPT        = self.user_options[self.user_script_env_field],
                     ROOT_LCG_VIEW_PATH     = self.lcg_view_path,
                     USER                   = username,
+                    NB_USER                = username,
                     USER_ID                = self.user_uid,
                     NB_UID                 = self.user_uid,
                     HOME                   = homepath,


### PR DESCRIPTION
Since now two images will be supported (Alma9 and CentOS7), the URLs of both need to be configured.

The Alma9 URL is configured via chart settings, and the old CentOS7 image URL is configured via an option of our kubespawner. We make the spawner switch image if centos7 is found in the selected platform.

Goes together with https://github.com/swan-cern/swan-charts/pull/192