### PR TITLE
Changes to the web form template related to Alma9

### DIFF
--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -138,6 +138,8 @@
         // adjust clusters option for lcg
         var selectCluster = document.getElementById('clusterOptions');
         selectCluster.innerHTML = '';
+        // Make sure Spark cluster options are enabled on LCG release change
+        selectCluster.removeAttribute('disabled');
 
         for( var i = 0 ; i < lcgData.clusters.length ; i++ ){
             var lcgCluster = lcgData.clusters[i];
@@ -170,6 +172,27 @@
         }
     }
 
+    /**
+     * Modifies the selection of Spark clusters depending on the chosen platform
+     */
+    function adjust_spark() {
+        var platformOptions = document.getElementById('platformOptions');
+        var clusterOptions  = document.getElementById('clusterOptions');
+
+        var isAlma = platformOptions.selectedOptions[0].text.startsWith('AlmaLinux 9');
+
+        if (isAlma) {
+            // Disable Spark cluster selection, since Spark is still not supported
+            // on Alma9
+            clusterOptions.setAttribute('disabled', '');
+            clusterOptions.selectedIndex = 0;
+        }
+        else {
+            // On CentOS7, make sure cluster selection is enabled
+            clusterOptions.removeAttribute('disabled');
+        }
+    }
+
     window.onload = adjust_form;
 //-->
 </script>
@@ -194,7 +217,7 @@
        <span class='nb'>The combination of compiler version and flags.</span>
     </div>
     </label>
-    <select id="platformOptions" name="platform"></select>
+    <select id="platformOptions" name="platform" onchange="adjust_spark();"></select>
     <br>
     <label for="scriptenvOption">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
     <div style="display:none;" id="scriptenvDetails">

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -1,5 +1,6 @@
 <style> .nb{ font-weight:normal } </style>
 <style> .nbs{ font-weight:normal; font-size:small } </style>
+<style> .news{ font-weight:normal; background-color:yellow } </style>
 <script type="text/javascript">
 <!--
 
@@ -175,6 +176,9 @@
 <div>
     <label for="placeholder">
     <span class='nb' id="optionsHeader">Specify the configuration parameters for the SWAN container that will be created for you.</span>
+    </label>
+    <label for="alma9">
+    <span class='news' id="alma9">Select <b>AlmaLinux 9</b> as Platform to try out our new experimental Alma9 image with <b>JupyterLab</b> as default interface! More information <a target="_blank" href="https://swan.docs.cern.ch/alma9/">here</a>.</span>
     </label>
     <br><br>
     <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>


### PR DESCRIPTION
This PR adds:
- A message to the form to advertise the Alma9 platform and JupyterLab.
- The automatic disabling of the Spark cluster if the selected platform is Alma9 (see commit message for details on why).

![Screenshot from 2024-01-10 22-47-25](https://github.com/swan-cern/jupyterhub-extensions/assets/8089558/4068a866-49ba-49d0-afd4-d35acd218d78)
