### PR TITLE
Move GPU resource specification to pod hook

### DIFF
--- a/SwanSpawner/swanspawner/swankubespawner.py
+++ b/SwanSpawner/swanspawner/swankubespawner.py
@@ -25,16 +25,6 @@ class SwanKubeSpawner(define_SwanSpawner_from(KubeSpawner)):
         """Perform extra configurations required for SWAN session spawning in
         kubernetes.
         """
-
-        if self._gpu_requested():
-            self.extra_resource_guarantees["nvidia.com/gpu"] = "1"
-            self.extra_resource_limits["nvidia.com/gpu"] = "1"
-        elif "nvidia.com/gpu" in self.extra_resource_guarantees:
-            del self.extra_resource_guarantees["nvidia.com/gpu"]
-            del self.extra_resource_limits["nvidia.com/gpu"]
-
-        # Resource requests and limits for user pods
-
         # CPU limit is set to what the user selects in the form
         # The request (guarantee) is statically set in the chart;
         # the resulting overcommit is acceptable since users stay idle
@@ -104,7 +94,7 @@ class SwanKubeSpawner(define_SwanSpawner_from(KubeSpawner)):
         """ Set base environmental variables for swan jupyter docker image """
         env = super().get_env()
 
-        if self._gpu_requested():
+        if self.gpu_requested():
             env.update(dict(
                 # Configure OpenCL to use NVIDIA backend
                 OCL_ICD_FILENAMES = 'libnvidia-opencl.so.1',
@@ -112,6 +102,6 @@ class SwanKubeSpawner(define_SwanSpawner_from(KubeSpawner)):
 
         return env
 
-    def _gpu_requested(self):
+    def gpu_requested(self):
         """Returns true if the user requested a GPU"""
         return "cu" in self.user_options[self.lcg_rel_field]

--- a/SwanSpawner/swanspawner/swankubespawner.py
+++ b/SwanSpawner/swanspawner/swankubespawner.py
@@ -89,19 +89,3 @@ class SwanKubeSpawner(define_SwanSpawner_from(KubeSpawner)):
                         await self.api.delete_namespaced_secret(hadoop_secret_name, namespace)
                     except ApiException as e:
                         self.log.error('Error deleting secret {namespace}:{hadoop_secret_name}: {e}')
-
-    def get_env(self):
-        """ Set base environmental variables for swan jupyter docker image """
-        env = super().get_env()
-
-        if self.gpu_requested():
-            env.update(dict(
-                # Configure OpenCL to use NVIDIA backend
-                OCL_ICD_FILENAMES = 'libnvidia-opencl.so.1',
-            ))
-
-        return env
-
-    def gpu_requested(self):
-        """Returns true if the user requested a GPU"""
-        return "cu" in self.user_options[self.lcg_rel_field]


### PR DESCRIPTION
This is in the context of providing a dynamic mechanism to check whether a GPU user is a participant of a SWAN event, and if so allocate their session on a certain subset of resources with a configured GPU flavor.

Two configurable parameters are added here for that purpose:
- event_role: name of the auth role that participants of a SWAN event have.
- event_gpu_name: name of the GPU resource assigned to those participants.

Doing this in the pod hook is also more elegant since we will not need anymore to erase the value of the last resource specification that was done.

This goes together with https://github.com/swan-cern/swan-charts/pull/216