### PR TITLE
Custom envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,3 @@ ENV/
 
 # Mac os
 .DS_Store
-
-# Docker
-Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ ENV/
 
 # Mac os
 .DS_Store
+
+# Docker
+Dockerfile

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -31,16 +31,16 @@ class SpawnHandlersConfigs(SingletonConfigurable):
 
     user_script_env_field = 'scriptenv'
     
-    cernbox_pattern = Unicode(
-        default_value=r'^\/?([\w-]+\/)*[\w-]+\/?$',
+    eos_pattern = Unicode(
+        default_value=r'^(?:\$CERNBOX_HOME\/)?\/?([\w-]+\/)*[\w-]+\/?$',
         config=True,
-        help='Regular expression pattern for requirements provided by a CERNBox file.'
+        help='Regular expression pattern for requirements provided by a EOS folder.'
     )
 
-    cernbox_special_type = Unicode(
-        default_value='cernbox',
+    eos_special_type = Unicode(
+        default_value='eos',
         config=True,
-        help='Special type for requirements provided by a CERNBox folder.'
+        help='Special type for requirements provided by a EOS folder.'
     )
 
     git_pattern = Unicode(

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -17,7 +17,7 @@ class SpawnHandlersConfigs(SingletonConfigurable):
     
     source_type = 'source_type'
 
-    customenv_type = 'customenv_type'
+    builder = 'builder'
     
     customenv_type_version = 'customenv_type_version'
 

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -17,9 +17,9 @@ class SpawnHandlersConfigs(SingletonConfigurable):
 
     source_type = 'source_type'
 
-    customenv_type = 'customenv_type'
+    builder = 'builder'
     
-    customenv_type_version = 'customenv_type_version'
+    builder_version = 'builder_version'
             
     repository_type = 'repository_type'
 

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -14,6 +14,14 @@ class SpawnHandlersConfigs(SingletonConfigurable):
     """
         Singleton class where all the configurations are stored
     """
+    
+    source_type = 'source_type'
+
+    customenv_type = 'customenv_type'
+    
+    customenv_type_version = 'customenv_type_version'
+            
+    requirements = 'requirements'
 
     software_source = 'software_source'
 

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -32,7 +32,7 @@ class SpawnHandlersConfigs(SingletonConfigurable):
     user_script_env_field = 'scriptenv'
     
     eos_pattern = Unicode(
-        default_value=r'^(?:\$CERNBOX_HOME\/)?\/?([\w-]+\/)*[\w-]+\/?$',
+        default_value=r'^(?:\$CERNBOX|(?:/[^/\n]+)*/[^/\n]+)$',
         config=True,
         help='Regular expression pattern for requirements provided by a EOS folder.'
     )

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -14,8 +14,8 @@ class SpawnHandlersConfigs(SingletonConfigurable):
     """
         Singleton class where all the configurations are stored
     """
-    
-    source_type = 'source_type'
+
+    software_source = 'software_source'
 
     builder = 'builder'
     

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -93,12 +93,6 @@ class SpawnHandlersConfigs(SingletonConfigurable):
         help='Default platform configuration for LCG views.'
     )
 
-    notebook = Unicode(
-        default_value='notebook',
-        config=True,
-        help='Name of the notebook file to launch with its arguments'
-    )
-
     local_home = Bool(
         default_value=False,
         config=True,

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -25,72 +25,24 @@ class SpawnHandlersConfigs(SingletonConfigurable):
 
     repository = 'repository'
 
+    project_folder = 'project_folder'
+
     lcg_rel_field = 'LCG-rel'
 
     platform_field = 'platform'
 
     user_script_env_field = 'scriptenv'
 
-    user_n_cores = 'ncores'
-
-    user_memory = 'memory'
-
     spark_cluster_field = 'spark-cluster'
 
-    condor_pool = 'condor-pool'
+    customenv_special_type = 'customenv'
 
-    eos_pattern = Unicode(
-        default_value=r'^(?:\$CERNBOX|(?:/[^/\n]+)*/[^/\n]+)?$',
-        config=True,
-        help='Regular expression pattern for the repository provided by a EOS folder.'
-    )
-
-    eos_special_type = Unicode(
-        default_value='eos',
-        config=True,
-        help='Special type for the repository provided by a EOS folder.'
-    )
-
-    git_pattern = Unicode(
-        default_value=r'https?://(?:github\.com|gitlab\.cern\.ch)/([^/\s]+)/([^/\s]+)/?',
-        config=True,
-        help='Regular expression pattern for the repository provided by a GitLab or GitHub repository.'
-    )
-
-    git_special_type = Unicode(
-        default_value='git',
-        config=True,
-        help='Special repository type for Git repositories.'
-    )
-
-    lcg_special_type = Unicode(
-        default_value='lcg',
-        config=True,
-        help='Special type for default sourcing.'
-    )
-
-    customenv_special_type = Unicode(
-        default_value='customenv',
-        config=True,
-        help='Special type for sourcing the environment.'
-    )
-
-    accpy_special_type = Unicode(
-        default_value='accpy',
-        config=True,
-        help='Special type for custom environments.'
-    )
+    accpy_special_type = 'accpy'
 
     env_name = Unicode(
         default_value='{project_folder}_env',
         config=True,
         help='Name format for custom environment launched by the user.'
-    )
-
-    default_platform = Unicode(
-        default_value='x86_64-el9-gcc13-opt',
-        config=True,
-        help='Default platform configuration for LCG views.'
     )
 
     local_home = Bool(

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -21,7 +21,7 @@ class SpawnHandlersConfigs(SingletonConfigurable):
     
     builder_version = 'builder_version'
             
-    repository_type = 'repository_type'
+    repo_type = 'repo_type'
 
     repository = 'repository'
 

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -20,8 +20,6 @@ class SpawnHandlersConfigs(SingletonConfigurable):
     customenv_type = 'customenv_type'
     
     customenv_type_version = 'customenv_type_version'
-            
-    requirements = 'requirements'
 
     software_source = 'software_source'
 

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -14,45 +14,59 @@ class SpawnHandlersConfigs(SingletonConfigurable):
     """
         Singleton class where all the configurations are stored
     """
-    
+
     source_type = 'source_type'
 
     customenv_type = 'customenv_type'
     
     customenv_type_version = 'customenv_type_version'
+            
+    repository_type = 'repository_type'
 
-    requirements = 'requirements'
-    
-    requirements_type = 'requirements_type'
-    
+    repository = 'repository'
+
     lcg_rel_field = 'LCG-rel'
+
+    platform_field = 'platform'
+
+    user_script_env_field = 'scriptenv'
+
+    user_n_cores = 'ncores'
+
+    user_memory = 'memory'
 
     spark_cluster_field = 'spark-cluster'
 
-    user_script_env_field = 'scriptenv'
-    
+    condor_pool = 'condor-pool'
+
     eos_pattern = Unicode(
-        default_value=r'^(?:\$CERNBOX|(?:/[^/\n]+)*/[^/\n]+)$',
+        default_value=r'^(?:\$CERNBOX|(?:/[^/\n]+)*/[^/\n]+)?$',
         config=True,
-        help='Regular expression pattern for requirements provided by a EOS folder.'
+        help='Regular expression pattern for the repository provided by a EOS folder.'
     )
 
     eos_special_type = Unicode(
         default_value='eos',
         config=True,
-        help='Special type for requirements provided by a EOS folder.'
+        help='Special type for the repository provided by a EOS folder.'
     )
 
     git_pattern = Unicode(
         default_value=r'https?://(?:github\.com|gitlab\.cern\.ch)/([^/\s]+)/([^/\s]+)/?',
         config=True,
-        help='Regular expression pattern for requirements provided by a GitLab or GitHub repository.'
+        help='Regular expression pattern for the repository provided by a GitLab or GitHub repository.'
     )
 
     git_special_type = Unicode(
         default_value='git',
         config=True,
-        help='Special requirements type for Git repositories.'
+        help='Special repository type for Git repositories.'
+    )
+
+    lcg_special_type = Unicode(
+        default_value='lcg',
+        config=True,
+        help='Special type for default sourcing.'
     )
 
     customenv_special_type = Unicode(
@@ -71,6 +85,18 @@ class SpawnHandlersConfigs(SingletonConfigurable):
         default_value='{project_folder}_env',
         config=True,
         help='Name format for custom environment launched by the user.'
+    )
+
+    default_platform = Unicode(
+        default_value='x86_64-el9-gcc13-opt',
+        config=True,
+        help='Default platform configuration for LCG views.'
+    )
+
+    notebook = Unicode(
+        default_value='notebook',
+        config=True,
+        help='Name of the notebook file to launch with its arguments'
     )
 
     local_home = Bool(

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -19,19 +19,11 @@ class SpawnHandlersConfigs(SingletonConfigurable):
 
     builder = 'builder'
     
-    customenv_type_version = 'customenv_type_version'
-
-    software_source = 'software_source'
-
-    builder = 'builder'
-    
     builder_version = 'builder_version'
             
     repository_type = 'repository_type'
 
     repository = 'repository'
-
-    project_folder = 'project_folder'
 
     lcg_rel_field = 'LCG-rel'
 

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -20,14 +20,58 @@ class SpawnHandlersConfigs(SingletonConfigurable):
     customenv_type = 'customenv_type'
     
     customenv_type_version = 'customenv_type_version'
-            
-    requirements = 'requirements'
 
+    requirements = 'requirements'
+    
+    requirements_type = 'requirements_type'
+    
     lcg_rel_field = 'LCG-rel'
 
     spark_cluster_field = 'spark-cluster'
 
     user_script_env_field = 'scriptenv'
+    
+    cernbox_pattern = Unicode(
+        default_value=r'^\/?([\w-]+\/)*[\w-]+\/?$',
+        config=True,
+        help='Regular expression pattern for requirements provided by a CERNBox file.'
+    )
+
+    cernbox_special_type = Unicode(
+        default_value='cernbox',
+        config=True,
+        help='Special type for requirements provided by a CERNBox folder.'
+    )
+
+    git_pattern = Unicode(
+        default_value=r'https?://(?:github\.com|gitlab\.cern\.ch)/([^/\s]+)/([^/\s]+)/?',
+        config=True,
+        help='Regular expression pattern for requirements provided by a GitLab or GitHub repository.'
+    )
+
+    git_special_type = Unicode(
+        default_value='git',
+        config=True,
+        help='Special requirements type for Git repositories.'
+    )
+
+    customenv_special_type = Unicode(
+        default_value='customenv',
+        config=True,
+        help='Special type for sourcing the environment.'
+    )
+
+    accpy_special_type = Unicode(
+        default_value='accpy',
+        config=True,
+        help='Special type for custom environments.'
+    )
+
+    env_name = Unicode(
+        default_value='{project_folder}_env',
+        config=True,
+        help='Name format for custom environment launched by the user.'
+    )
 
     local_home = Bool(
         default_value=False,

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -25,8 +25,6 @@ class SpawnHandlersConfigs(SingletonConfigurable):
 
     repository = 'repository'
 
-    project_folder = 'project_folder'
-
     lcg_rel_field = 'LCG-rel'
 
     platform_field = 'platform'
@@ -38,12 +36,6 @@ class SpawnHandlersConfigs(SingletonConfigurable):
     customenv_special_type = 'customenv'
 
     accpy_special_type = 'accpy'
-
-    env_name = Unicode(
-        default_value='{project_folder}_env',
-        config=True,
-        help='Name format for custom environment launched by the user.'
-    )
 
     local_home = Bool(
         default_value=False,

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -14,6 +14,14 @@ class SpawnHandlersConfigs(SingletonConfigurable):
     """
         Singleton class where all the configurations are stored
     """
+    
+    source_type = 'source_type'
+
+    customenv_type = 'customenv_type'
+    
+    customenv_type_version = 'customenv_type_version'
+            
+    requirements = 'requirements'
 
     lcg_rel_field = 'LCG-rel'
 

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -15,7 +15,7 @@ class SpawnHandlersConfigs(SingletonConfigurable):
         Singleton class where all the configurations are stored
     """
 
-    source_type = 'source_type'
+    software_source = 'software_source'
 
     builder = 'builder'
     

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -31,6 +31,8 @@ class SpawnHandlersConfigs(SingletonConfigurable):
 
     repository = 'repository'
 
+    project_folder = 'project_folder'
+
     lcg_rel_field = 'LCG-rel'
 
     platform_field = 'platform'

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -105,6 +105,9 @@ class SpawnHandler(JHSpawnHandler):
         for key, byte_list in self.request.files.items():
             form_options["%s_file" % key] = byte_list
 
+        if form_options[configs.source_type][0] == "customenv" and form_options[configs.requirements][0] == '':
+            raise web.HTTPError(400, "Requirements not provided")
+
         start_time_spawn = time.time()
 
         options = {}
@@ -172,7 +175,6 @@ class SpawnHandler(JHSpawnHandler):
                 user,
                 default=url_path_join(self.hub.base_url, "spawn-pending", user.escaped_name, server_name),
             )
-
         self.redirect(next_url)
 
     async def _render_form_wrapper(self, for_user, message=''):

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -56,31 +56,12 @@ class SpawnHandler(JHSpawnHandler):
             self.finish(form)
             return
 
-        if not self.request.query_arguments:
-            try:
-                await super().get(for_user, server_name)
-            except web.HTTPError as e:
-                form = await self._render_form_wrapper(user, message=e.message)
-                self.finish(form)
-                return
-        else:
-            query_options = {key: [value[0].encode("utf-8")] for key, value in parse_qs(urlparse(unquote(self.request.uri)).query).items()}
-            self.request.body_arguments = {
-                configs.source_type: query_options.get(configs.source_type, [bytes(configs.lcg_special_type.encode("utf-8"))]),
-                configs.repository: query_options.get(configs.repository, [b'']),
-                configs.repository_type: query_options.get(configs.repository_type, [b'']),
-                configs.customenv_type: query_options.get(configs.customenv_type, [b'']),
-                configs.customenv_type_version: query_options.get(configs.customenv_type_version, [b'']),
-                configs.lcg_rel_field: query_options.get(configs.lcg_rel_field, [b'']),
-                configs.platform_field: query_options.get(configs.platform_field, [bytes(configs.default_platform.encode("utf-8"))]),
-                configs.spark_cluster_field: query_options.get(configs.spark_cluster_field, [b'']),
-                configs.user_script_env_field: query_options.get(configs.user_script_env_field, [b'']),
-                configs.condor_pool: query_options.get(configs.condor_pool, [b'']),
-                configs.user_n_cores: query_options.get(configs.user_n_cores, [b'2']),
-                configs.user_memory: query_options.get(configs.user_memory, [b'8']),
-                configs.notebook: query_options.get(configs.notebook, [b'']),
-            }
-            return await self.post(user_name=for_user, server_name=server_name)
+        try:
+            await super().get(for_user, server_name)
+        except web.HTTPError as e:
+            form = await self._render_form_wrapper(user, message=e.message)
+            self.finish(form)
+            return
 
     @web.authenticated
     def post(self, user_name=None, server_name=''):
@@ -198,7 +179,6 @@ class SpawnHandler(JHSpawnHandler):
             query_params = {
                 "env": configs.env_name.format(project_folder=project_folder),
                 "repo": options.get(configs.repository),
-                configs.notebook: options.get(configs.notebook, ''),
             }
             if options.get(configs.customenv_type) == configs.accpy_special_type:
                 query_params[options.get(configs.customenv_type)] = options.get(configs.customenv_type_version)
@@ -210,7 +190,7 @@ class SpawnHandler(JHSpawnHandler):
         else:
             next_url = self.get_next_url(
                 user,
-                default=url_path_join(self.hub.base_url, "spawn-pending", user.escaped_name, server_name, options.get(configs.notebook, '')),
+                default=url_path_join(self.hub.base_url, "spawn-pending", user.escaped_name, server_name),
             )
         self.redirect(next_url)
 

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -159,7 +159,6 @@ class SpawnHandler(JHSpawnHandler):
         if options.get(configs.source_type) == configs.customenv_special_type:
             # Add the query parameters to the URL
             query_params = {
-                "env": configs.env_name.format(project_folder=options.get(configs.project_folder)), # {reponame}_env or {lastfolder}_env
                 "repo": options.get(configs.repository),
             }
             if options.get(configs.builder) == configs.accpy_special_type:

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -115,10 +115,10 @@ class SpawnHandler(JHSpawnHandler):
                 raise ValueError("Requirements not provided")
 
             # Dont allow the session to spawn if the requirements are not valid
-            cernbox_match = re.match(configs.cernbox_pattern, options[configs.requirements])
+            eos_match = re.match(configs.eos_pattern, options[configs.requirements])
             git_match = re.match(configs.git_pattern, options[configs.requirements])
-            if options[configs.requirements_type] == configs.cernbox_special_type and not cernbox_match:
-                raise ValueError(f"Invalid CERNBox folder for requirements: {options[configs.requirements]}")
+            if options[configs.requirements_type] == configs.eos_special_type and not eos_match:
+                raise ValueError(f"Invalid EOS folder for requirements: {options[configs.requirements]}")
             if options[configs.requirements_type] == configs.git_special_type and not git_match:
                 raise ValueError(f"Invalid Git repository for requirements: {options[configs.requirements]}")
 

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -118,7 +118,7 @@ class SpawnHandler(JHSpawnHandler):
             eos_match = re.match(configs.eos_pattern, options[configs.requirements])
             git_match = re.match(configs.git_pattern, options[configs.requirements])
             if options[configs.requirements_type] == configs.eos_special_type and not eos_match:
-                raise ValueError(f"Invalid EOS folder for requirements: {options[configs.requirements]}")
+                raise ValueError(f"Invalid EOS path for requirements: {options[configs.requirements]}")
             if options[configs.requirements_type] == configs.git_special_type and not git_match:
                 raise ValueError(f"Invalid Git repository for requirements: {options[configs.requirements]}")
 
@@ -170,8 +170,8 @@ class SpawnHandler(JHSpawnHandler):
             self.set_login_cookie(user)
 
         if options[configs.source_type] == configs.customenv_special_type:
-            # Redirect to the customenvs page with the correct query parameters
-            project_folder = options[configs.requirements].split('/').pop()
+            # Redirect to the customenvs page with the correct query parameters (/eos/user/.../requirements.txt)
+            project_folder = options[configs.requirements].split('/')[-2]
             if options[configs.requirements].startswith('http'):
                 project_folder = git_match[2] if git_match else user.escaped_name
             

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -137,7 +137,6 @@ class SpawnHandler(JHSpawnHandler):
                     user, options, time.time() - start_time_spawn)
 
         except Exception as e:
-
             self._log_spawn_metrics(
                 user, options, time.time() - start_time_spawn, e)
 
@@ -231,7 +230,7 @@ class SpawnHandler(JHSpawnHandler):
                 metrics.append((metric, (date, 1)))
 
         spawn_context_key = ".".join(
-            [options.get(configs.lcg_rel_field, "CustomEnv"), options.get(configs.spark_cluster_field, "")])
+            [options.get(configs.lcg_rel_field, "CustomEnv"), options.get(configs.spark_cluster_field, "none")])
         if not spawn_exception:
             # Add spawn success (no exception) and duration to the log and send as metrics
             spawn_exc_class = "None"

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -156,7 +156,7 @@ class SpawnHandler(JHSpawnHandler):
         if current_user is user:
             self.set_login_cookie(user)
 
-        if options.get(configs.source_type) == configs.customenv_special_type:
+        if options.get(configs.software_source) == configs.customenv_special_type:
             # Add the query parameters to the URL
             query_params = {
                 "repo": options.get(configs.repository),

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -160,7 +160,7 @@ class SpawnHandler(JHSpawnHandler):
             # Add the query parameters to the URL
             query_params = {
                 "repo": options.get(configs.repository),
-                "repo_type": options.get(configs.repository_type),
+                "repo_type": options.get(configs.repo_type),
             }
             if options.get(configs.builder) == configs.accpy_special_type:
                 query_params[options.get(configs.builder)] = options.get(configs.builder_version)

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -157,7 +157,7 @@ class SpawnHandler(JHSpawnHandler):
         if current_user is user:
             self.set_login_cookie(user)
 
-        if options.get(configs.source_type) == configs.customenv_special_type:            
+        if options.get(configs.source_type) == configs.customenv_special_type:
             # Add the query parameters to the URL
             query_params = {
                 "env": configs.env_name.format(project_folder=options.get(configs.project_folder)), # {reponame}_env or {lastfolder}_env
@@ -231,7 +231,7 @@ class SpawnHandler(JHSpawnHandler):
                 metrics.append((metric, (date, 1)))
 
         spawn_context_key = ".".join(
-            [options.get(configs.lcg_rel_field, "CustomEnv"), options.get(configs.spark_cluster_field, "NoSpark")])
+            [options.get(configs.lcg_rel_field, "CustomEnv"), options.get(configs.spark_cluster_field, "")])
         if not spawn_exception:
             # Add spawn success (no exception) and duration to the log and send as metrics
             spawn_exc_class = "None"

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -168,10 +168,7 @@ class SpawnHandler(JHSpawnHandler):
             # Execution SwanCustomEnvs extension with the corresponding query arguments
             next_url = url_concat(url_path_join("user", user.escaped_name, "customenvs", server_name), query_params)
         else: # LCG release
-            next_url = self.get_next_url(
-                user,
-                default=url_path_join(self.hub.base_url, "spawn-pending", user.escaped_name, server_name),
-            )
+            next_url = url_path_join(self.hub.base_url, "spawn-pending", user.escaped_name, server_name)
 
         self.redirect(next_url)
 

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -5,7 +5,6 @@
 
 import time
 import os
-import re
 from jupyterhub.handlers.pages import SpawnHandler as JHSpawnHandler
 from jupyterhub.utils import url_path_join, maybe_future
 from jupyterhub.scopes import needs_scope

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -166,10 +166,7 @@ class SpawnHandler(JHSpawnHandler):
                 query_params[options.get(configs.builder)] = options.get(configs.builder_version)
 
             # Execution SwanCustomEnvs extension with the corresponding query arguments
-            next_url = self.get_next_url(
-                user,
-                default=url_concat(url_path_join("user", user.escaped_name, "customenvs", server_name), query_params),
-            )
+            next_url = url_concat(url_path_join("user", user.escaped_name, "customenvs", server_name), query_params)
         else: # LCG release
             next_url = self.get_next_url(
                 user,

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -185,6 +185,7 @@ class SpawnHandler(JHSpawnHandler):
                 user,
                 default=url_path_join(self.hub.base_url, "spawn-pending", user.escaped_name, server_name),
             )
+
         self.redirect(next_url)
 
     async def _render_form_wrapper(self, for_user, message=''):

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -110,10 +110,6 @@ class SpawnHandler(JHSpawnHandler):
         options = {}
         try:
             options = await maybe_future(spawner.run_options_from_form(form_options))
-
-            if options.get(configs.source_type) == configs.customenv_special_type and not options.get(configs.repository):
-                raise ValueError("Repository not provided")
-
             await self.spawn_single_user(user, server_name=server_name, options=options)
 
             # if spawn future is already done it is success,

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -160,6 +160,7 @@ class SpawnHandler(JHSpawnHandler):
             # Add the query parameters to the URL
             query_params = {
                 "repo": options.get(configs.repository),
+                "repo_type": options.get(configs.repository_type),
             }
             if options.get(configs.builder) == configs.accpy_special_type:
                 query_params[options.get(configs.builder)] = options.get(configs.builder_version)

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -110,18 +110,6 @@ class SpawnHandler(JHSpawnHandler):
         options = {}
         try:
             options = await maybe_future(spawner.run_options_from_form(form_options))
-
-            if options[configs.source_type] == configs.customenv_special_type and not options[configs.requirements]:
-                raise ValueError("Requirements not provided")
-
-            # Dont allow the session to spawn if the requirements are not valid
-            cernbox_match = re.match(configs.cernbox_pattern, options[configs.requirements])
-            git_match = re.match(configs.git_pattern, options[configs.requirements])
-            if options[configs.requirements_type] == configs.cernbox_special_type and not cernbox_match:
-                raise ValueError(f"Invalid CERNBox folder for requirements: {options[configs.requirements]}")
-            if options[configs.requirements_type] == configs.git_special_type and not git_match:
-                raise ValueError(f"Invalid Git repository for requirements: {options[configs.requirements]}")
-
             await self.spawn_single_user(user, server_name=server_name, options=options)
 
             # if spawn future is already done it is success,

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -5,6 +5,7 @@
 
 import time
 import os
+import re
 from jupyterhub.handlers.pages import SpawnHandler as JHSpawnHandler
 from jupyterhub.utils import url_path_join, maybe_future
 from jupyterhub.scopes import needs_scope
@@ -105,13 +106,22 @@ class SpawnHandler(JHSpawnHandler):
         for key, byte_list in self.request.files.items():
             form_options["%s_file" % key] = byte_list
 
-        if form_options[configs.source_type][0] == "customenv" and form_options[configs.requirements][0] == '':
-            raise web.HTTPError(400, "Requirements not provided")
-
         start_time_spawn = time.time()
 
         try:
             options = await maybe_future(spawner.run_options_from_form(form_options))
+
+            if options[configs.source_type] == configs.customenv_special_type and not options[configs.requirements]:
+                raise ValueError("Requirements not provided")
+
+            # Dont allow the session to spawn if the requirements are not valid
+            cernbox_match = re.match(configs.cernbox_pattern, options[configs.requirements])
+            git_match = re.match(configs.git_pattern, options[configs.requirements])
+            if options[configs.requirements_type] == configs.cernbox_special_type and not cernbox_match:
+                raise ValueError(f"Invalid CERNBox folder for requirements: {options[configs.requirements]}")
+            if options[configs.requirements_type] == configs.git_special_type and not git_match:
+                raise ValueError(f"Invalid Git repository for requirements: {options[configs.requirements]}")
+
             await self.spawn_single_user(user, server_name=server_name, options=options)
 
             # if spawn future is already done it is success,
@@ -159,11 +169,17 @@ class SpawnHandler(JHSpawnHandler):
         if current_user is user:
             self.set_login_cookie(user)
 
-        query_params = {"env": f"{user.escaped_name}_env", "req": options[configs.requirements]}
-        if options[configs.customenv_type] == "accpy":
-            query_params[configs.customenv_type] = options[configs.customenv_type_version]
+        if options[configs.source_type] == configs.customenv_special_type:
+            # Redirect to the customenvs page with the correct query parameters
+            project_folder = options[configs.requirements].split('/').pop()
+            if options[configs.requirements].startswith('http'):
+                project_folder = git_match[2] if git_match else user.escaped_name
+            
+            # Add the query parameters to the URL
+            query_params = {"env": configs.env_name.format(project_folder=project_folder), "req": options[configs.requirements]}
+            if options[configs.customenv_type] == configs.accpy_special_type:
+                query_params[options[configs.customenv_type]] = options[configs.customenv_type_version]
 
-        if options[configs.source_type] == "customenv":
             next_url = self.get_next_url(
                 user,
                 default=url_concat(url_path_join("user", user.escaped_name, "customenvs", server_name), query_params),

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -5,7 +5,6 @@
 
 import time
 import os
-import re
 from jupyterhub.handlers.pages import SpawnHandler as JHSpawnHandler
 from jupyterhub.utils import url_path_join, maybe_future
 from jupyterhub.scopes import needs_scope
@@ -16,7 +15,6 @@ import datetime
 import calendar
 import pickle
 import struct
-from urllib.parse import urlparse, parse_qs, unquote
 from socket import (
     socket,
     AF_INET,
@@ -169,8 +167,8 @@ class SpawnHandler(JHSpawnHandler):
                 "env": configs.env_name.format(project_folder=options.get(configs.project_folder)), # {reponame}_env or {lastfolder}_env
                 "repo": options.get(configs.repository),
             }
-            if options.get(configs.customenv_type) == configs.accpy_special_type:
-                query_params[options.get(configs.customenv_type)] = options.get(configs.customenv_type_version)
+            if options.get(configs.builder) == configs.accpy_special_type:
+                query_params[options.get(configs.builder)] = options.get(configs.builder_version)
 
             # Execution SwanCustomEnvs extension with the corresponding query arguments
             next_url = self.get_next_url(

--- a/SwanSpawner/.bumpversion.cfg
+++ b/SwanSpawner/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.3
+current_version = 1.2.4
 commit = True
 tag = True
 tag_name = SwanSpawner/v{new_version}

--- a/SwanSpawner/.bumpversion.cfg
+++ b/SwanSpawner/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.2
+current_version = 1.2.3
 commit = True
 tag = True
 tag_name = SwanSpawner/v{new_version}

--- a/SwanSpawner/.bumpversion.cfg
+++ b/SwanSpawner/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.4
+current_version = 1.2.5
 commit = True
 tag = True
 tag_name = SwanSpawner/v{new_version}

--- a/SwanSpawner/swanspawner/_version.py
+++ b/SwanSpawner/swanspawner/_version.py
@@ -1,3 +1,3 @@
 # please don't modify this file,
 # this is automatically updated by bump2version
-__version__ = '1.2.3'
+__version__ = '1.2.4'

--- a/SwanSpawner/swanspawner/_version.py
+++ b/SwanSpawner/swanspawner/_version.py
@@ -1,3 +1,3 @@
 # please don't modify this file,
 # this is automatically updated by bump2version
-__version__ = '1.2.2'
+__version__ = '1.2.3'

--- a/SwanSpawner/swanspawner/_version.py
+++ b/SwanSpawner/swanspawner/_version.py
@@ -1,3 +1,3 @@
 # please don't modify this file,
 # this is automatically updated by bump2version
-__version__ = '1.2.4'
+__version__ = '1.2.5'

--- a/SwanSpawner/swanspawner/swandockerspawner.py
+++ b/SwanSpawner/swanspawner/swandockerspawner.py
@@ -12,7 +12,6 @@ from traitlets import (
     Unicode,
     Bool,
     Int,
-    Dict
 )
 
 from socket import (
@@ -97,12 +96,6 @@ class SwanDockerSpawner(define_SwanSpawner_from(SystemUserSpawner)):
             self.extra_host_config['port_bindings'] = {}
             self.extra_create_kwargs['ports'] = []
 
-            if self.lcg_rel_field not in self.user_options:
-                # session spawned via the API, in binder start notebook with jovyan user
-                self.extra_create_kwargs['working_dir'] = "/home/jovyan"
-                self.extra_create_kwargs['user'] = 'jovyan'
-                self.extra_create_kwargs['command'] = ["jupyterhub-singleuser","--ip=0.0.0.0","--NotebookApp.default_url=/lab"]
-
             # Avoid overriding the default container output port, defined by the Spawner
             if not self.use_internal_ip:
                 self.extra_host_config['port_bindings'][self.port] = (self.host_ip,)
@@ -146,17 +139,17 @@ class SwanDockerSpawner(define_SwanSpawner_from(SystemUserSpawner)):
         """Perform the operations necessary for mounting
         EOS, GPU support, authenticating HDFS and authenticating spark clusters.
         """
-        
+
         # default values when spawned via API (e.g binder)
         with open(self.options_form_config) as json_file:
             options_form_config_data = json.load(json_file)
 
         username = self.user.name
-        platform = self.user_options.get(self.platform_field,options_form_config_data["lcg_options"][1]['platforms'][0]['value'])
-        lcg_rel = self.user_options.get(self.lcg_rel_field,options_form_config_data["lcg_options"][1]["lcg"]["value"])
-        cluster = self.user_options.get(self.spark_cluster_field,options_form_config_data["lcg_options"][1]['clusters'][0]['value'])
-        cpu_quota = self.user_options.get(self.user_n_cores,int(options_form_config_data["lcg_options"][1]['cores'][0]['value']))
-        mem_limit = self.user_options.get(self.user_memory,options_form_config_data["lcg_options"][1]['memory'][0]['value'] + 'G')
+        platform = self.user_options.get(self.platform_field, options_form_config_data['lcg_options'][1]['platforms'][1]['value']) # Default: Alma9 (x86_64-el9-gcc13-opt)
+        lcg_rel = self.user_options.get(self.lcg_rel_field, options_form_config_data['lcg_options'][1]['lcg']['value']) # Default: LCG_105a_swan
+        cluster = self.user_options.get(self.spark_cluster_field, options_form_config_data['lcg_options'][1]['clusters'][0]['value']) # Default: none
+        cpu_quota = self.user_options.get(self.user_n_cores, int(options_form_config_data['lcg_options'][1]['cores'][0]['value'])) # Default: 2
+        mem_limit = self.user_options.get(self.user_memory, options_form_config_data['lcg_options'][1]['memory'][0]['value'] + 'G') # Default: 8G
 
         try:
             start_time_configure_user = time.time()

--- a/SwanSpawner/swanspawner/swandockerspawner.py
+++ b/SwanSpawner/swanspawner/swandockerspawner.py
@@ -152,11 +152,11 @@ class SwanDockerSpawner(define_SwanSpawner_from(SystemUserSpawner)):
             options_form_config_data = json.load(json_file)
 
         username = self.user.name
-        platform = self.user_options.get(self.platform_field,options_form_config_data["options"][1]['platforms'][0]['value'])
-        lcg_rel = self.user_options.get(self.lcg_rel_field,options_form_config_data["options"][1]["lcg"]["value"])
-        cluster = self.user_options.get(self.spark_cluster_field,options_form_config_data["options"][1]['clusters'][0]['value'])
-        cpu_quota = self.user_options.get(self.user_n_cores,int(options_form_config_data["options"][1]['cores'][0]['value']))
-        mem_limit = self.user_options.get(self.user_memory,options_form_config_data["options"][1]['memory'][0]['value'] + 'G')
+        platform = self.user_options.get(self.platform_field,options_form_config_data["lcg_options"][1]['platforms'][0]['value'])
+        lcg_rel = self.user_options.get(self.lcg_rel_field,options_form_config_data["lcg_options"][1]["lcg"]["value"])
+        cluster = self.user_options.get(self.spark_cluster_field,options_form_config_data["lcg_options"][1]['clusters'][0]['value'])
+        cpu_quota = self.user_options.get(self.user_n_cores,int(options_form_config_data["lcg_options"][1]['cores'][0]['value']))
+        mem_limit = self.user_options.get(self.user_memory,options_form_config_data["lcg_options"][1]['memory'][0]['value'] + 'G')
 
         try:
             start_time_configure_user = time.time()

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -173,7 +173,7 @@ def define_SwanSpawner_from(base_class):
             #FIXME remove userrid and username and just use jovyan 
             #FIXME clean JPY env variables
             env.update(dict(
-                SOFTWARE_SOURCE            = self.user_options[self.software_source],
+                SOFTWARE_SOURCE        = self.user_options[self.software_source],
                 USER                   = username,
                 NB_USER                = username,
                 USER_ID                = self.user_uid,

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -32,8 +32,6 @@ def define_SwanSpawner_from(base_class):
 
         repository = 'repository'
         
-        notebook = 'notebook'
-
         lcg_rel_field = 'LCG-rel'
 
         platform_field = 'platform'
@@ -121,7 +119,6 @@ def define_SwanSpawner_from(base_class):
             if len(aux_req) == 2:
                 customenv_type, customenv_type_version = aux_req
             repository, repository_type = '', ''
-            notebook = ''
             if source_type == self.customenv_special_type:
                 lcg, platform = '', self.default_platform
                 repository = formdata[self.repository][0]
@@ -135,10 +132,6 @@ def define_SwanSpawner_from(base_class):
                 # If the user wants to use CERNBOX_HOME, replace it with the user's CERNBOX_HOME path
                 elif repository.startswith('$CERNBOX_HOME'):
                     repository = self.replace_eos_home(repository)
-            if self.notebook in formdata:
-                notebook = formdata[self.notebook][0]
-                if notebook.startswith('$CERNBOX_HOME'):
-                    notebook = self.replace_eos_home(notebook)
 
             options = {}
             options[self.source_type]           = source_type
@@ -146,7 +139,6 @@ def define_SwanSpawner_from(base_class):
             options[self.customenv_type_version] = customenv_type_version
             options[self.repository]            = repository
             options[self.repository_type]       = repository_type
-            options[self.notebook]              = notebook
             options[self.lcg_rel_field]         = lcg
             options[self.platform_field]        = platform
             options[self.user_script_env_field] = formdata[self.user_script_env_field][0]

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -7,6 +7,7 @@ import re, json
 import os
 import time
 from socket import gethostname
+from urllib.parse import unquote
 from traitlets import Unicode, Bool, Int
 
 from jinja2 import Environment, FileSystemLoader

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -42,6 +42,8 @@ def define_SwanSpawner_from(base_class):
 
         user_memory = 'memory'
 
+        use_jupyterlab_field = 'use-jupyterlab'
+
         spark_cluster_field = 'spark-cluster'
 
         condor_pool = 'condor-pool'
@@ -96,6 +98,7 @@ def define_SwanSpawner_from(base_class):
             options[self.software_source]       = formdata[self.software_source][0]
             options[self.user_n_cores]          = int(formdata[self.user_n_cores][0])
             options[self.user_memory]           = formdata[self.user_memory][0] + 'G'
+            options[self.use_jupyterlab_field]  = formdata.get(self.use_jupyterlab_field, 'unchecked')[0]
             if options[self.software_source] == self.customenv_special_type:
                 options[self.builder]               = builder
                 options[self.builder_version]       = builder_version
@@ -146,6 +149,12 @@ def define_SwanSpawner_from(base_class):
                 env['ROOT_LCG_VIEW_PLATFORM'] = self.user_options[self.platform_field]
                 env['USER_ENV_SCRIPT']        = self.user_options[self.user_script_env_field]
                 env['ROOT_LCG_VIEW_PATH']     = self.lcg_view_path
+
+            # Enable JupyterLab interface
+            if self.user_options[self.use_jupyterlab_field] == 'checked':
+                env.update(dict(
+                    SWAN_USE_JUPYTERLAB = 'true'
+                ))
 
             # Enable configuration for CERN HTCondor pool
             if self.user_options.get(self.condor_pool, 'none') != 'none':

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -130,8 +130,6 @@ def define_SwanSpawner_from(base_class):
                         raise ValueError(f"Invalid EOS repository: {repository}")
                 else: # git option
                     git_match = re.match(self.git_pattern, repository)
-                    print("repository: ", repository)
-                    print("git_match: ", git_match)
                     if not git_match:
                         raise ValueError(f"Invalid Git repository: {repository}")
 

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -131,7 +131,6 @@ def define_SwanSpawner_from(base_class):
             #FIXME remove userrid and username and just use jovyan 
             #FIXME clean JPY env variables
             env.update(dict(
-                SOFTWARE_SOURCE        = self.user_options[self.software_source],
                 USER                   = username,
                 NB_USER                = username,
                 USER_ID                = self.user_uid,

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -24,8 +24,6 @@ def define_SwanSpawner_from(base_class):
 
         software_source = 'software_source'
 
-        software_source = 'software_source'
-
         builder = 'builder'
 
         builder_version = 'builder_version'
@@ -33,6 +31,7 @@ def define_SwanSpawner_from(base_class):
         repository_type = 'repository_type'
 
         repository = 'repository'
+
         lcg_rel_field = 'LCG-rel'
 
         platform_field = 'platform'
@@ -54,7 +53,7 @@ def define_SwanSpawner_from(base_class):
         lcg_special_type = 'lcg'
 
         eos_special_type = 'eos'
-        
+
         options_form_config = Unicode(
             config=True,
             help='Path to configuration file for options_form rendering.'
@@ -123,8 +122,6 @@ def define_SwanSpawner_from(base_class):
             """ Set base environmental variables for swan jupyter docker image """
             env = super().get_env()
 
-            deploy_lcg = True if self.user_options[self.config_type].upper() == 'LCG' or self.user_options[self.customenv_type].upper() == "CVMFS" else False
-
             username = self.user.name
             if self.local_home:
                 homepath = "/scratch/%s" %(username)
@@ -162,15 +159,6 @@ def define_SwanSpawner_from(base_class):
             # Enable configuration for CERN HTCondor pool
             if self.user_options.get(self.condor_pool, 'none') != 'none':
                 env['CERN_HTCONDOR'] = 'true'
-
-            # Enable configuration for LCG and custom environments
-            if self.user_options[self.source_type] == "lcg":
-                env['ROOT_LCG_VIEW_NAME']     = self.user_options[self.lcg_rel_field]
-                env['ROOT_LCG_VIEW_PLATFORM'] = self.user_options[self.platform_field]
-                env['USER_ENV_SCRIPT']        = self.user_options[self.user_script_env_field]
-                env['ROOT_LCG_VIEW_PATH']     = self.lcg_view_path
-            elif self.user_options[self.source_type] == "customenv":
-                env['AUTOENV'] = self.user_options[self.autoenv]
 
             return env
 

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -21,6 +21,8 @@ def define_SwanSpawner_from(base_class):
     """
 
     class SwanSpawner(base_class):
+   
+        source_type = 'source_type'
 
         software_source = 'software_source'
 
@@ -161,6 +163,13 @@ def define_SwanSpawner_from(base_class):
             # Enable configuration for CERN HTCondor pool
             if self.user_options.get(self.condor_pool, 'none') != 'none':
                 env['CERN_HTCONDOR'] = 'true'
+            if self.user_options[self.source_type] == "lcg":
+                env['ROOT_LCG_VIEW_NAME']     = self.user_options[self.lcg_rel_field]
+                env['ROOT_LCG_VIEW_PLATFORM'] = self.user_options[self.platform_field]
+                env['USER_ENV_SCRIPT']        = self.user_options[self.user_script_env_field]
+                env['ROOT_LCG_VIEW_PATH']     = self.lcg_view_path
+            else:
+                env['PS1'] = f'[\\u@{username}_env \\W]\\$'
 
             return env
 

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -33,7 +33,6 @@ def define_SwanSpawner_from(base_class):
         repository_type = 'repository_type'
 
         repository = 'repository'
-
         lcg_rel_field = 'LCG-rel'
 
         platform_field = 'platform'

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -56,7 +56,7 @@ def define_SwanSpawner_from(base_class):
         eos_special_type = 'eos'
 
         eos_pattern = Unicode(
-            default_value=r'^(?:\$CERNBOX_HOME|/eos)(?:/[^<>\|\\:()&;,/\n]+)*/?$',
+            default_value=r'^(?:\$CERNBOX_HOME|/eos/user/[a-zA-Z]/[^<>\|\\:()&;,/\n]+)(?:/[^<>\|\\:()&;,/\n]+)*/?$',
             config=True,
             help='Regular expression pattern for the repository provided by a EOS folder.'
         )
@@ -178,35 +178,23 @@ def define_SwanSpawner_from(base_class):
 
             #FIXME remove userrid and username and just use jovyan 
             #FIXME clean JPY env variables
-            if self.lcg_rel_field in self.user_options:
-                # session spawned via the form
-                env.update(dict(
-                    SOURCE_TYPE            = self.user_options[self.source_type],
-                    USER                   = username,
-                    NB_USER                = username,
-                    USER_ID                = self.user_uid,
-                    NB_UID                 = self.user_uid,
-                    HOME                   = homepath,
-                    EOS_PATH_FORMAT        = self.eos_path_format,
-                    SERVER_HOSTNAME        = os.uname().nodename
-                ))
+            env.update(dict(
+                SOURCE_TYPE            = self.user_options[self.source_type],
+                USER                   = username,
+                NB_USER                = username,
+                USER_ID                = self.user_uid,
+                NB_UID                 = self.user_uid,
+                HOME                   = homepath,
+                EOS_PATH_FORMAT        = self.eos_path_format,
+                SERVER_HOSTNAME        = os.uname().nodename
+            ))
 
-                # Set LCG-related variables
-                if self.user_options[self.source_type] == self.lcg_special_type:
-                    env['ROOT_LCG_VIEW_NAME']     = self.user_options[self.lcg_rel_field]
-                    env['ROOT_LCG_VIEW_PLATFORM'] = self.user_options[self.platform_field]
-                    env['USER_ENV_SCRIPT']        = self.user_options[self.user_script_env_field]
-                    env['ROOT_LCG_VIEW_PATH']     = self.lcg_view_path
-            else:
-                # session spawned via the API
-                env.update(dict(
-                    USER                   = "jovyan",
-                    HOME                   = "/home/jovyan",
-                    NB_USER                = 'jovyan',
-                    USER_ID                = 1000,
-                    NB_UID                 = 1000,
-                    SERVER_HOSTNAME        = os.uname().nodename,
-                ))
+            # Set LCG-related variables
+            if self.user_options[self.source_type] == self.lcg_special_type:
+                env['ROOT_LCG_VIEW_NAME']     = self.user_options[self.lcg_rel_field]
+                env['ROOT_LCG_VIEW_PLATFORM'] = self.user_options[self.platform_field]
+                env['USER_ENV_SCRIPT']        = self.user_options[self.user_script_env_field]
+                env['ROOT_LCG_VIEW_PATH']     = self.lcg_view_path
 
             # Enable configuration for CERN HTCondor pool
             if self.user_options[self.condor_pool] != 'none':

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -110,7 +110,7 @@ def define_SwanSpawner_from(base_class):
             lcg = formdata[self.lcg_rel_field][0]
             platform = formdata[self.platform_field][0]
             builder_data = formdata[self.builder][0].lower().split('-')
-            builder, builder_version = builder_data if len(builder_data) == 2 else '', ''
+            builder, builder_version = (builder_data if len(builder_data) == 2 else '', '')
             repository, repository_type = '', ''
             project_folder = self.user.name
 

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -200,7 +200,7 @@ def define_SwanSpawner_from(base_class):
             if self.user_options[self.condor_pool] != 'none':
                 env['CERN_HTCONDOR'] = 'true'
 
-            # Enable configuration for LCG and custom environments
+            # Set LCG-related variables
             if self.user_options[self.source_type] != self.customenv_special_type:
                 env['ROOT_LCG_VIEW_NAME']     = self.user_options[self.lcg_rel_field]
                 env['ROOT_LCG_VIEW_PLATFORM'] = self.user_options[self.platform_field]

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -23,7 +23,7 @@ def define_SwanSpawner_from(base_class):
 
     class SwanSpawner(base_class):
 
-        source_type = 'source_type'
+        software_source = 'software_source'
 
         builder = 'builder'
 
@@ -107,14 +107,14 @@ def define_SwanSpawner_from(base_class):
             return repo_path.replace('$CERNBOX_HOME', eos_path.rstrip('/'))
 
         def options_from_form(self, formdata):
-            source_type = formdata[self.source_type][0]
+            software_source = formdata[self.software_source][0]
             lcg_rel = formdata[self.lcg_rel_field][0]
             platform = formdata[self.platform_field][0]
             repository, repository_type = '', ''
             # Builders are specified in builder-builderversion format
             builder, builder_version = formdata[self.builder][0].lower().split('-')
 
-            if source_type == self.customenv_special_type:
+            if software_source == self.customenv_special_type:
                 lcg_rel, platform = '', ''
                 repository = formdata[self.repository][0]
                 repository_type = formdata[self.repository_type][0]
@@ -124,10 +124,8 @@ def define_SwanSpawner_from(base_class):
 
                 # Do not allow the session to spawn if the repository is not valid
                 if repository_type == self.eos_special_type:
-                    print(f"Repository: {repository}")
                     # Get the last folder of the repository by default
                     repository = self.replace_cernbox_home(repository)
-                    print(f"Repository2: {repository}")
 
                     eos_match = re.match(self.eos_pattern, repository)
                     if not eos_match:
@@ -141,7 +139,7 @@ def define_SwanSpawner_from(base_class):
                     repository = git_match.group(0)
 
             options = {}
-            options[self.source_type]           = source_type
+            options[self.software_source]           = software_source
             options[self.user_n_cores]          = int(formdata[self.user_n_cores][0])
             options[self.user_memory]           = formdata[self.user_memory][0] + 'G'
             options[self.lcg_rel_field]         = lcg_rel
@@ -149,7 +147,7 @@ def define_SwanSpawner_from(base_class):
             options[self.user_script_env_field] = formdata[self.user_script_env_field][0]
             options[self.spark_cluster_field]   = formdata[self.spark_cluster_field][0] if self.spark_cluster_field in formdata.keys() else 'none'
             options[self.condor_pool]           = formdata[self.condor_pool][0]
-            if source_type == self.customenv_special_type:
+            if software_source == self.customenv_special_type:
                 options[self.builder]               = builder
                 options[self.builder_version]       = builder_version
                 options[self.repository]            = repository
@@ -175,7 +173,7 @@ def define_SwanSpawner_from(base_class):
             #FIXME remove userrid and username and just use jovyan 
             #FIXME clean JPY env variables
             env.update(dict(
-                SOURCE_TYPE            = self.user_options[self.source_type],
+                SOFTWARE_SOURCE            = self.user_options[self.software_source],
                 USER                   = username,
                 NB_USER                = username,
                 USER_ID                = self.user_uid,
@@ -186,7 +184,7 @@ def define_SwanSpawner_from(base_class):
             ))
 
             # Set LCG-related variables
-            if self.user_options[self.source_type] == self.lcg_special_type:
+            if self.user_options[self.software_source] == self.lcg_special_type:
                 env['ROOT_LCG_VIEW_NAME']     = self.user_options[self.lcg_rel_field]
                 env['ROOT_LCG_VIEW_PLATFORM'] = self.user_options[self.platform_field]
                 env['USER_ENV_SCRIPT']        = self.user_options[self.user_script_env_field]

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -54,7 +54,7 @@ def define_SwanSpawner_from(base_class):
         eos_special_type = 'eos'
 
         eos_pattern = Unicode(
-            default_value=r'^/eos/user/[a-z]/[^<>\|\\:()&;,\n]+(/[^<>\|\\:()&;,\n]+)+/?$',
+            default_value=r'^/eos/user/[a-z](/[^<>\|\\:()&;,\n]+)+/?$',
             config=True,
             help='Regular expression pattern for the repository provided by a EOS folder.'
         )
@@ -124,8 +124,10 @@ def define_SwanSpawner_from(base_class):
 
                 # Do not allow the session to spawn if the repository is not valid
                 if repository_type == self.eos_special_type:
+                    print(f"Repository: {repository}")
                     # Get the last folder of the repository by default
                     repository = self.replace_cernbox_home(repository)
+                    print(f"Repository2: {repository}")
 
                     eos_match = re.match(self.eos_pattern, repository)
                     if not eos_match:

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -7,7 +7,6 @@ import re, json
 import os
 import time
 from socket import gethostname
-from urllib.parse import unquote
 from traitlets import Unicode, Bool, Int
 
 from jinja2 import Environment, FileSystemLoader

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -122,6 +122,8 @@ def define_SwanSpawner_from(base_class):
             """ Set base environmental variables for swan jupyter docker image """
             env = super().get_env()
 
+            deploy_lcg = True if self.user_options[self.config_type].upper() == 'LCG' or self.user_options[self.customenv_type].upper() == "CVMFS" else False
+
             username = self.user.name
             if self.local_home:
                 homepath = "/scratch/%s" %(username)

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -25,15 +25,15 @@ def define_SwanSpawner_from(base_class):
         source_type = 'source_type'
 
         builder = 'builder'
-        
+
         builder_version = 'builder_version'
-                
+
         repository_type = 'repository_type'
 
         repository = 'repository'
-        
+
         project_folder = 'project_folder'
-        
+
         lcg_rel_field = 'LCG-rel'
 
         platform_field = 'platform'

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -33,8 +33,6 @@ def define_SwanSpawner_from(base_class):
 
         repository = 'repository'
 
-        project_folder = 'project_folder'
-
         lcg_rel_field = 'LCG-rel'
 
         platform_field = 'platform'
@@ -56,7 +54,7 @@ def define_SwanSpawner_from(base_class):
         eos_special_type = 'eos'
 
         eos_pattern = Unicode(
-            default_value=r'^(?:\$CERNBOX_HOME|/eos/user/[a-zA-Z]/[^<>\|\\:()&;,/\n]+)(?:/[^<>\|\\:()&;,/\n]+)*/?$',
+            default_value=r'^/eos/user/[a-z]/[^<>\|\\:()&;,\n]+(/[^<>\|\\:()&;,\n]+)+/?$',
             config=True,
             help='Regular expression pattern for the repository provided by a EOS folder.'
         )
@@ -113,7 +111,6 @@ def define_SwanSpawner_from(base_class):
             lcg_rel = formdata[self.lcg_rel_field][0]
             platform = formdata[self.platform_field][0]
             repository, repository_type = '', ''
-            project_folder = self.user.name
             # Builders are specified in builder-builderversion format
             builder, builder_version = formdata[self.builder][0].lower().split('-')
 
@@ -129,7 +126,6 @@ def define_SwanSpawner_from(base_class):
                 if repository_type == self.eos_special_type:
                     # Get the last folder of the repository by default
                     repository = self.replace_cernbox_home(repository)
-                    project_folder =  repository.split('/')[-1]
 
                     eos_match = re.match(self.eos_pattern, repository)
                     if not eos_match:
@@ -141,7 +137,6 @@ def define_SwanSpawner_from(base_class):
                         raise ValueError(f"Invalid Git repository: {repository}")
 
                     repository = git_match.group(0)
-                    project_folder = git_match.group(2)
 
             options = {}
             options[self.source_type]           = source_type
@@ -156,7 +151,6 @@ def define_SwanSpawner_from(base_class):
                 options[self.builder]               = builder
                 options[self.builder_version]       = builder_version
                 options[self.repository]            = repository
-                options[self.project_folder]        = project_folder
                 options[self.repository_type]       = repository_type
 
             self.offload = options[self.spark_cluster_field] != 'none'

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -21,7 +21,7 @@ def define_SwanSpawner_from(base_class):
     """
 
     class SwanSpawner(base_class):
-   
+
         source_type = 'source_type'
 
         software_source = 'software_source'
@@ -163,13 +163,15 @@ def define_SwanSpawner_from(base_class):
             # Enable configuration for CERN HTCondor pool
             if self.user_options.get(self.condor_pool, 'none') != 'none':
                 env['CERN_HTCONDOR'] = 'true'
+
+            # Enable configuration for LCG and custom environments
             if self.user_options[self.source_type] == "lcg":
                 env['ROOT_LCG_VIEW_NAME']     = self.user_options[self.lcg_rel_field]
                 env['ROOT_LCG_VIEW_PLATFORM'] = self.user_options[self.platform_field]
                 env['USER_ENV_SCRIPT']        = self.user_options[self.user_script_env_field]
                 env['ROOT_LCG_VIEW_PATH']     = self.lcg_view_path
-            else:
-                env['PS1'] = f'[\\u@{username}_env \\W]\\$'
+            elif self.user_options[self.source_type] == "customenv":
+                env['AUTOENV'] = self.user_options[self.autoenv]
 
             return env
 

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -144,21 +144,20 @@ def define_SwanSpawner_from(base_class):
                     project_folder = git_match.group(2)
 
             options = {}
-            options[self.source_type]               = source_type
-            options[self.user_n_cores]              = int(formdata[self.user_n_cores][0])
-            options[self.user_memory]               = formdata[self.user_memory][0] + 'G'
+            options[self.source_type]           = source_type
+            options[self.user_n_cores]          = int(formdata[self.user_n_cores][0])
+            options[self.user_memory]           = formdata[self.user_memory][0] + 'G'
+            options[self.lcg_rel_field]         = lcg_rel
+            options[self.platform_field]        = platform
+            options[self.user_script_env_field] = formdata[self.user_script_env_field][0]
+            options[self.spark_cluster_field]   = formdata[self.spark_cluster_field][0] if self.spark_cluster_field in formdata.keys() else 'none'
+            options[self.condor_pool]           = formdata[self.condor_pool][0]
             if source_type == self.customenv_special_type:
                 options[self.builder]               = builder
                 options[self.builder_version]       = builder_version
                 options[self.repository]            = repository
                 options[self.project_folder]        = project_folder
                 options[self.repository_type]       = repository_type
-            else:
-                options[self.lcg_rel_field]         = lcg_rel
-                options[self.platform_field]        = platform
-                options[self.user_script_env_field] = formdata[self.user_script_env_field][0]
-                options[self.spark_cluster_field]   = formdata[self.spark_cluster_field][0] if self.spark_cluster_field in formdata.keys() else 'none'
-                options[self.condor_pool]           = formdata[self.condor_pool][0]
 
             self.offload = options[self.spark_cluster_field] != 'none'
 

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -139,7 +139,7 @@ def define_SwanSpawner_from(base_class):
                     repository = git_match.group(0)
 
             options = {}
-            options[self.software_source]           = software_source
+            options[self.software_source]       = software_source
             options[self.user_n_cores]          = int(formdata[self.user_n_cores][0])
             options[self.user_memory]           = formdata[self.user_memory][0] + 'G'
             options[self.lcg_rel_field]         = lcg_rel

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -100,9 +100,9 @@ def define_SwanSpawner_from(base_class):
             options[self.user_memory]           = formdata[self.user_memory][0] + 'G'
             options[self.use_jupyterlab_field]  = formdata.get(self.use_jupyterlab_field, 'unchecked')[0]
             if options[self.software_source] == self.customenv_special_type:
-                options[self.builder]               = builder
-                options[self.builder_version]       = builder_version
-                options[self.repository]            = formdata[self.repository][0]
+                options[self.builder]         = builder
+                options[self.builder_version] = builder_version
+                options[self.repository]      = formdata[self.repository][0]
                 options[self.repo_type]       = formdata[self.repo_type][0]
 
                 if not options[self.repository]:

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -23,7 +23,7 @@ def define_SwanSpawner_from(base_class):
 
     class SwanSpawner(base_class):
 
-        source_type = 'source_type'
+        software_source = 'software_source'
 
         software_source = 'software_source'
 

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -27,6 +27,18 @@ def define_SwanSpawner_from(base_class):
 
     class SwanSpawner(base_class):
 
+        config_type = 'configType'
+        
+        env_name = 'env_name'
+        
+        requirements = 'requirements'
+
+        customenv_type = 'customenvType'
+        
+        accpy_version = 'accpy_version'
+        
+        custom_python = 'custom_python'
+        
         lcg_rel_field = 'LCG-rel'
 
         platform_field = 'platform'
@@ -79,6 +91,12 @@ def define_SwanSpawner_from(base_class):
 
         def options_from_form(self, formdata):
             options = {}
+            options[self.config_type]           = formdata[self.config_type][0]
+            options[self.env_name]              = formdata[self.env_name][0]
+            options[self.requirements]          = formdata[self.requirements][0]
+            options[self.customenv_type]        = formdata[self.customenv_type][0]
+            options[self.accpy_version]         = formdata[self.accpy_version][0]
+            options[self.custom_python]         = formdata[self.custom_python][0]
             options[self.lcg_rel_field]         = formdata[self.lcg_rel_field][0]
             options[self.platform_field]        = formdata[self.platform_field][0]
             options[self.user_script_env_field] = formdata[self.user_script_env_field][0]
@@ -95,6 +113,8 @@ def define_SwanSpawner_from(base_class):
             """ Set base environmental variables for swan jupyter docker image """
             env = super().get_env()
 
+            deploy_lcg = True if self.user_options[self.config_type].upper() == 'LCG' or self.user_options[self.customenv_type].upper() == "CVMFS" else False
+
             username = self.user.name
             if self.local_home:
                 homepath = "/scratch/%s" %(username)
@@ -109,10 +129,16 @@ def define_SwanSpawner_from(base_class):
             if self.lcg_rel_field in self.user_options:
                 # session spawned via the form
                 env.update(dict(
+                    LCG_ENVIRONMENT        = deploy_lcg,
                     ROOT_LCG_VIEW_NAME     = self.user_options[self.lcg_rel_field],
                     ROOT_LCG_VIEW_PLATFORM = self.user_options[self.platform_field],
                     USER_ENV_SCRIPT        = self.user_options[self.user_script_env_field],
+                    ENV_NAME               = self.user_options[self.env_name],
+                    REQUIREMENTS           = self.user_options[self.requirements],
+                    ACCPY_VERSION          = self.user_options[self.accpy_version],
+                    CUSTOM_PYTHON          = self.user_options[self.custom_python],
                     ROOT_LCG_VIEW_PATH     = self.lcg_view_path,
+                    PS1                    = f"[\u@{self.env_name} \W]\$",
                     USER                   = username,
                     NB_USER                = username,
                     USER_ID                = self.user_uid,

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -28,7 +28,7 @@ def define_SwanSpawner_from(base_class):
 
         builder_version = 'builder_version'
 
-        repository_type = 'repository_type'
+        repo_type = 'repo_type'
 
         repository = 'repository'
 
@@ -103,7 +103,7 @@ def define_SwanSpawner_from(base_class):
                 options[self.builder]               = builder
                 options[self.builder_version]       = builder_version
                 options[self.repository]            = formdata[self.repository][0]
-                options[self.repository_type]       = formdata[self.repository_type][0]
+                options[self.repo_type]       = formdata[self.repo_type][0]
 
                 if not options[self.repository]:
                     raise ValueError("No Repository specified")

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -37,8 +37,6 @@ def define_SwanSpawner_from(base_class):
 
         requirements = 'requirements'
 
-        autoenv = 'autoenv'
-                        
         lcg_rel_field = 'LCG-rel'
 
         platform_field = 'platform'
@@ -104,7 +102,6 @@ def define_SwanSpawner_from(base_class):
             if len(aux_req) == 2:
                 customenv_type, customenv_type_version = aux_req
             requirements, requirements_type = '', ''
-            autoenv = formdata[self.autoenv][0] if self.autoenv in formdata.keys() else ''
             if source_type == self.customenv_special_type:
                 lcg, platform = '', 'x86_64-el9-gcc13-opt'
                 requirements = formdata[self.requirements][0]
@@ -116,7 +113,6 @@ def define_SwanSpawner_from(base_class):
             options[self.customenv_type_version] = customenv_type_version
             options[self.requirements]          = requirements
             options[self.requirements_type]     = requirements_type
-            options[self.autoenv]               = autoenv
             options[self.lcg_rel_field]         = lcg
             options[self.platform_field]        = platform
             options[self.user_script_env_field] = formdata[self.user_script_env_field][0]
@@ -178,7 +174,7 @@ def define_SwanSpawner_from(base_class):
                 env['USER_ENV_SCRIPT']        = self.user_options[self.user_script_env_field]
                 env['ROOT_LCG_VIEW_PATH']     = self.lcg_view_path
             elif self.user_options[self.source_type] == "customenv":
-                env['AUTOENV'] = self.user_options[self.autoenv]
+                env['AUTOENV'] = "true"
 
             return env
 

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -119,6 +119,9 @@ def define_SwanSpawner_from(base_class):
                 repository = formdata[self.repository][0]
                 repository_type = formdata[self.repository_type][0]
 
+                if not repository:
+                    raise ValueError("Repository not provided")
+
                 # Do not allow the session to spawn if the repository is not valid
                 if repository_type == self.eos_special_type:
                     # Get the last folder of the repository by default
@@ -138,8 +141,8 @@ def define_SwanSpawner_from(base_class):
 
             options = {}
             options[self.source_type]           = source_type
-            options[self.builder]        = builder
-            options[self.builder_version] = builder_version
+            options[self.builder]               = builder
+            options[self.builder_version]       = builder_version
             options[self.repository]            = repository
             options[self.project_folder]        = project_folder
             options[self.repository_type]       = repository_type

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -113,7 +113,7 @@ def define_SwanSpawner_from(base_class):
             """ Set base environmental variables for swan jupyter docker image """
             env = super().get_env()
 
-            deploy_lcg = True if self.user_options[self.config_type].upper() == 'LCG' or self.user_options[self.customenv_type].upper() == "CVMFS" else False
+            deploy_lcg = "true" if self.user_options[self.config_type].upper() == 'LCG' or self.user_options[self.customenv_type].upper() == "CVMFS" else "false"
 
             username = self.user.name
             if self.local_home:
@@ -138,6 +138,7 @@ def define_SwanSpawner_from(base_class):
                     ACCPY_VERSION          = self.user_options[self.accpy_version],
                     CUSTOM_PYTHON          = self.user_options[self.custom_python],
                     ROOT_LCG_VIEW_PATH     = self.lcg_view_path,
+                    PS1                    = f"[\\u@{self.env_name} \\W]\\$",
                     USER                   = username,
                     NB_USER                = username,
                     USER_ID                = self.user_uid,

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -53,7 +53,7 @@ def define_SwanSpawner_from(base_class):
         eos_special_type = 'eos'
 
         eos_pattern = Unicode(
-            default_value=r'^(?:\$CERNBOX|(?:/[^/\n]+)*/[^/\n]+)?$',
+            default_value=r'^(?:\$CERNBOX_HOME|/eos(?:/[^/\n]+)*/?)?$',
             config=True,
             help='Regular expression pattern for the repository provided by a EOS folder.'
         )
@@ -107,15 +107,15 @@ def define_SwanSpawner_from(base_class):
 
         def options_from_form(self, formdata):
             source_type = formdata[self.source_type][0]
-            lcg = formdata[self.lcg_rel_field][0]
+            lcg_rel = formdata[self.lcg_rel_field][0]
             platform = formdata[self.platform_field][0]
-            builder_data = formdata[self.builder][0].lower().split('-')
-            builder, builder_version = (builder_data if len(builder_data) == 2 else '', '')
             repository, repository_type = '', ''
             project_folder = self.user.name
+            # Builders are specified in builder-builderversion format
+            builder, builder_version = formdata[self.builder][0].lower().split('-')
 
             if source_type == self.customenv_special_type:
-                lcg, platform = '', ''
+                lcg_rel, platform = '', ''
                 repository = formdata[self.repository][0]
                 repository_type = formdata[self.repository_type][0]
 
@@ -146,7 +146,7 @@ def define_SwanSpawner_from(base_class):
             options[self.repository]            = repository
             options[self.project_folder]        = project_folder
             options[self.repository_type]       = repository_type
-            options[self.lcg_rel_field]         = lcg
+            options[self.lcg_rel_field]         = lcg_rel
             options[self.platform_field]        = platform
             options[self.user_script_env_field] = formdata[self.user_script_env_field][0]
             options[self.spark_cluster_field]   = formdata[self.spark_cluster_field][0] if self.spark_cluster_field in formdata.keys() else 'none'
@@ -155,7 +155,7 @@ def define_SwanSpawner_from(base_class):
             options[self.user_memory]           = formdata[self.user_memory][0] + 'G'
 
             self.offload = options[self.spark_cluster_field] != 'none'
-            
+
             return options
 
         def get_env(self):

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -138,7 +138,6 @@ def define_SwanSpawner_from(base_class):
                     ACCPY_VERSION          = self.user_options[self.accpy_version],
                     CUSTOM_PYTHON          = self.user_options[self.custom_python],
                     ROOT_LCG_VIEW_PATH     = self.lcg_view_path,
-                    PS1                    = f"[\u@{self.env_name} \W]\$",
                     USER                   = username,
                     NB_USER                = username,
                     USER_ID                = self.user_uid,

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -153,6 +153,54 @@
                 configElement.add(selectOption);
             }
         });
+
+        adjust_options();
+    }
+
+    /**
+     * Modifies the selection of Spark clusters and enables users to choose
+     * to use the JupyterLab interface depending on the chosen platform
+     */
+     function adjust_options() {
+        var platformOptions = document.getElementById('platformOptions');
+        var clusterOptions  = document.getElementById('clusterOptions');
+        var jupyterLabOption = document.getElementById("use-jupyterlab");
+
+        /**
+         * Store the chosen platform in a hidden form field, as disabled fields
+         * are not sent in the request
+         */ 
+        var hiddenPlatformOptions = document.getElementById('hiddenPlatformOptions');
+
+        var isAlma = platformOptions.selectedOptions[0].text.startsWith('AlmaLinux 9');
+        var isNXCALS = clusterOptions.selectedOptions[0].text.startsWith('BE NXCALS (NXCals)');
+
+        if (isAlma) {
+            /* On Alma9, make sure cluster selection is enabled and that users can
+            select the JupyterLab interface */
+            clusterOptions.removeAttribute('disabled');
+            jupyterLabOption.removeAttribute('disabled');
+        } else {
+            if (!isNXCALS) {
+                clusterOptions.setAttribute('disabled', '');
+                clusterOptions.selectedIndex = 0;
+            }
+
+            jupyterLabOption.setAttribute('disabled', '');
+        }
+
+        hiddenPlatformOptions.value = platformOptions.value;
+    }
+
+    function adjust_platforms() {
+        var platformOptions = document.getElementById('platformOptions');
+        var jupyterLabOption = document.getElementById('use-jupyterlab');
+
+        if (jupyterLabOption.checked) {
+            platformOptions.setAttribute('disabled', '');
+        } else {
+            platformOptions.removeAttribute('disabled');
+        }
     }
 
     /**
@@ -209,80 +257,6 @@
         } 
     }
 
-    /**
-     * Modifies the some elements according to the selected type of configuration (LCG or Custom Environments)
-     */
-    function toggle_forms() {
-        var lcgOption = document.getElementById('lcgOption');
-        var customenvOption = document.getElementById('customenvOption');
-        
-        var customenv_config = document.getElementById('customenv_config');
-        var external_config = document.getElementById('external_config');
-        var software_config = document.getElementById('software_config');
-        var autoenvOption = document.getElementById('autoenvOption');
-        var lcg_config = document.getElementById('lcg_config');
-
-        adjust_form();
-        if (lcgOption.checked) {
-            lcg_config.style.display = 'block';
-            customenv_config.style.display = 'none';
-            external_res_config.style.display = 'block';
-            adjust_spark();
-        } else if (customenvOption.checked) {
-            selectDefaultLCG('lcgReleaseOptions');
-            adjust_form();
-            selectAlma9('platformOptions');
-            software_config.style.display = 'none';
-            customenv_config.style.display = 'block';
-            external_res_config.style.display = 'none';
-        } 
-    }
-
-    /**
-     * Modifies the selection of Spark clusters depending on the chosen platform
-     */
-    function adjust_options() {
-        var platformOptions = document.getElementById('platformOptions');
-        var clusterOptions  = document.getElementById('clusterOptions');
-        var jupyterLabOption = document.getElementById("use-jupyterlab");
-
-        /**
-         * Store the chosen platform in a hidden form field, as disabled fields
-         * are not sent in the request
-         */ 
-        var hiddenPlatformOptions = document.getElementById('hiddenPlatformOptions');
-
-        var isAlma = platformOptions.selectedOptions[0].text.startsWith('AlmaLinux 9');
-        var isNXCALS = clusterOptions.selectedOptions[0].text.startsWith('BE NXCALS (NXCals)');
-
-        if (isAlma) {
-            /* On Alma9, make sure cluster selection is enabled and that users can
-            select the JupyterLab interface */
-            clusterOptions.removeAttribute('disabled');
-            jupyterLabOption.removeAttribute('disabled');
-        } else {
-            if (!isNXCALS) {
-                clusterOptions.setAttribute('disabled', '');
-                clusterOptions.selectedIndex = 0;
-            }
-
-            jupyterLabOption.setAttribute('disabled', '');
-        }
-
-        hiddenPlatformOptions.value = platformOptions.value;
-    }
-
-    function adjust_platforms() {
-        var platformOptions = document.getElementById('platformOptions');
-        var jupyterLabOption = document.getElementById('use-jupyterlab');
-
-        if (jupyterLabOption.checked) {
-            platformOptions.setAttribute('disabled', '');
-        } else {
-            platformOptions.removeAttribute('disabled');
-        }
-    }
-
     window.onload = toggle_form;
 //-->
 </script>
@@ -295,6 +269,22 @@
     <span class='news' id="alma9">Try out our new experimental interface based on <b>JupyterLab</b> and let us know your feedback!</span>
     </label>
     <br><br>
+    <label> User Interface <a href="#" onclick="toggle_visibility('userInterfaceDetails');"><span class='nbs'>more...</span></a></label>
+    <div style="display:none;" id="userInterfaceDetails">
+        <span class='nb'>JupyterLab is the latest web-based interactive development environment for notebooks, code and data. More information <a target="_blank" href="https://jupyterlab.readthedocs.io/en/stable/user/interface.html">here</a>.</span>
+    </div>
+    <div style="display: flex; align-items: center">
+        <input
+          id="use-jupyterlab"
+          type="checkbox"
+          name="use-jupyterlab"
+          value="checked"
+          style="display: inline; width: initial; margin: 0 8px 0 0"
+          onchange="adjust_platforms();"
+        />
+        <span> Try the new JupyterLab interface (experimental)</span>
+    </div>
+    <br>
 
     <!-- Source Type selection -->
     <div id="software_sourceSection">
@@ -310,25 +300,6 @@
         <input type="radio" id="customenvOption" name="software_source" value="customenv" onchange="toggle_form();" style="width: auto; height: auto; display: inline-block;">
         <label for="customenvOption">Custom Environment</label>
         <br><br>
-    <label> User Interface <a href="#" onclick="toggle_visibility('userInterfaceDetails');"><span class='nbs'>more...</span></a></label>
-    <div style="display:none;" id="userInterfaceDetails">
-        <span class='nb'>JupyterLab is the latest web-based interactive development environment for notebooks, code and data. More information <a target="_blank" href="https://jupyterlab.readthedocs.io/en/stable/user/interface.html">here</a>.</span>
-    </div>
-    <div style="display: flex; align-items: center">
-      <input
-        id="use-jupyterlab"
-        type="checkbox"
-        name="use-jupyterlab"
-        value="checked"
-        style="display: inline; width: initial; margin: 0 8px 0 0"
-        onchange="adjust_platforms();"
-      />
-      <span> Try the new JupyterLab interface (experimental)</span>
-    </div>
-    <br>
-    <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="lcgReleaseDetails">
-       <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
     </div>
     
     <!-- LCG configuration -->
@@ -336,21 +307,21 @@
         <div id="lcgReleaseSection">
             <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="lcgReleaseDetails">
-                    <span class='nb'>LCG release to use as software source. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG releases package info</a> page.</span>
+                    <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
                 </div>
             </label>
-            <select id="lcgReleaseOptions" name="LCG-rel" onchange="adjust_form();">
-            </select>
+            <select id="lcgReleaseOptions" name="LCG-rel" onchange="adjust_form();"></select>
         </div>
         <br>
         
         <div id="platformSection">
             <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="platformDetails">
-                    <span class='nb'>Operating system and compiler version.</span>
+                    <span class='nb'>The combination of compiler version and flags.</span>
                 </div>
             </label>
-            <select id="platformOptions" name="platform" onchange="adjust_spark();"></select>
+            <select id="platformOptions" name="platform" onchange="adjust_options();"></select>
+            <input type="hidden" id="hiddenPlatformOptions" name="platform">
         </div>
         <br>
         
@@ -394,18 +365,6 @@
             <select id="builderOptions" name="builder"></select>
         </div>
         <br>
-    </label>
-    <select id="platformOptions" onchange="adjust_options();"></select>
-    <input type="hidden" id="hiddenPlatformOptions" name="platform">
-    <br>
-    
-    <div id="plataformSection">
-        <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
-            <div style="display:none;" id="platformDetails">
-                <span class='nb'>The combination of compiler version and flags.</span>
-            </div>
-        </label>
-        <select id="platformOptions" name="platform" onchange="adjust_spark();"></select>
     </div>
     
     <!-- Resources configuration -->
@@ -428,55 +387,6 @@
                     <span class='nb'>Amount of memory allocated to the container.</span>
                 </div>
             </label>
-            <br>
-            <select id="requirements_dropdown" name="requirements_type" style="width: auto; height: auto; display: inline-block; border: 1px solid #ccc; background-color: #f7f7f7;">
-                  <option value="git">Git</option>
-                  <option value="cernbox">CERNBox</option>
-            </select>
-            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/env1" style="width: max-content; height: auto; display: inline-block;">
-        </div>
-        <br>
-        
-        <div id="customenv_typeSection">
-            <label for="customenv_typeOptions">Custom environment type <a href="#" onclick="toggle_visibility('customenv_typeDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="customenv_typeDetails">
-                    <span class='nb'>Type of custom environment to create (generic or community-specific).</a></span>
-                </div>
-            </label>
-            <select id="builderOptions" name="builder"></select>
-        </div>
-        <br>
-        <div id="autoenvSection">
-            <input type="checkbox" id="autoenvOption" name="autoenv" checked style="width: auto; height: auto; display: inline-block;">
-            <label for="autoenvOption" style="margin-right: 5%;">Automatically activation <a href="#" onclick="toggle_visibility('autoenvDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="autoenvDetails">
-                    <span class='nb'>Automatically activates the environment when opening the terminal.</span>
-                </div>
-            </label>
-        </div>
-        <br>
-    </div>
-    
-    <!-- Resources configuration -->
-    <div id="resources_config">
-        <h2>Session resources</h2>
-
-        <div id="coresSection">
-            <label for="coresOptions">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="ncoresDetails">
-                    <span class='nb'>Number of cores to associate to the container.</span>
-                </div>
-            </label>
-            <select id="coresOptions" name="ncores"></select>
-        </div>
-        <br>
-
-        <div id="memorySection">
-            <label for="memoryOptions">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="memoryDetails">
-                    <span class='nb'>Amount of Memory allocated to the container.</span>
-                </div>
-            </label>
             <select id="memoryOptions" name="memory"></select>
         </div>
         <br>
@@ -487,8 +397,8 @@
         <h2>External computing resources</h2>
         
         <div id="clusterSection">
-            <label for="clusterOptions">Spark cluster <a href="#" onclick="toggle_visibility('clusterDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="clusterDetails">
+            <label for="clusterOptions">Spark cluster <a href="#" onclick="toggle_visibility('sparkClusterDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="sparkClusterDetails">
                     <span class='nb'>Name of the Spark cluster to connect to from notebooks. See the <a target="_blank" href="https://hadoop-user-guide.web.cern.ch/">Hadoop User guide</a> and the <a target="_blank" href="https://sparktraining.web.cern.ch/">Spark training course</a></span>
                 </div>
             </label>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -6,7 +6,24 @@
 
     var formConfig = {{ options_form_config }};
 
-    var accpyVersions = ["2020.11", "2021.12", "2023.06"];
+    const customenv_types = [
+      {
+        "value": "python-python3",
+        "text": "Python 3"
+      },
+      {
+        "value": "accpy-2023.06",
+        "text": "Acc-Py 2023.06"
+      },
+      {
+        "value": "accpy-2021.12",
+        "text": "Acc-Py 2021.12"
+      },
+      {
+        "value": "accpy-2020.11",
+        "text": "Acc-Py 2020.11"
+      }
+    ];
 
     var formInitialized = false;
 
@@ -36,7 +53,6 @@
                 break;
             }
         }
-        selector.setAttribute('disabled', '');
     }
 
     /*
@@ -45,11 +61,10 @@
    function selectDefaultLCG(selector) {
         for (var i = 0; i < selector.options.length; i++) {
             if (selector.options[i].value === 'LCG_105_swan') {
-               selector.options[i].selected = true;
-               break;
+                selector.options[i].selected = true;
+                break;
             }
         }
-        selector.setAttribute('disabled', '');
     }
 
     /**
@@ -243,53 +258,31 @@
     function adjust_customenv() {
         var lcgOption = document.getElementById('lcgOption');
         var customenvOption = document.getElementById('customenvOption');
+        
         var customenv_config = document.getElementById('customenv_config');
         var external_config = document.getElementById('external_config');
-        var lcgSection = document.getElementById('lcgSection');
+        var software_config = document.getElementById('software_config');
         var lcgReleaseOptions = document.getElementById('lcgReleaseOptions');
         var platformOptions = document.getElementById('platformOptions');
         
         if (lcgOption.checked) {
+            software_config.style.display = 'block';
             customenv_config.style.display = 'none';
             external_config.style.display = 'block';
-            lcgSection.style.visibility = 'visible';
-            lcgReleaseOptions.removeAttribute('disabled');
-            lcgReleaseOptions.selectedIndex = 1;
-            platformOptions.selectedIndex = 0;
-            platformOptions.removeAttribute('disabled');
             adjust_form();
             adjust_spark();
-        } else if (customenvOption.checked ) {
+        } else if (customenvOption.checked) {
             selectDefaultLCG(lcgReleaseOptions);
             adjust_form();
             selectAlma9(platformOptions);
+            software_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_config.style.display = 'none';
-            adjust_accpy();
         } 
     }
 
     /**
-     * Modifies the some elements according to the selected Acc-Py version
-     */
-    function adjust_accpy() {
-        var accpyOption = document.getElementById('accpyOption');
-        var cvmfsOption = document.getElementById('cvmfsOption');
-        var otherOption = document.getElementById('otherOption');
-        
-        var lcgSection = document.getElementById('lcgSection');
-        var accpySection = document.getElementById('accpySection');
-        var pythonSection = document.getElementById('pythonSection');
-
-        lcgSection.style.visibility = !cvmfsOption.checked ? 'hidden' : 'visible';
-        accpySection.style.display = !accpyOption.checked ? 'none' : 'block';
-        pythonSection.style.display = !otherOption.checked ? 'none' : 'block';
-    }
-
-
-    /**
-     * Modifies the selection of Spark clusters and enables users to choose
-     * to use the JupyterLab interface depending on the chosen platform
+     * Modifies the selection of Spark clusters depending on the chosen platform
      */
     function adjust_options() {
         var platformOptions = document.getElementById('platformOptions');
@@ -478,40 +471,41 @@
                     <span class='nb'>Amount of memory allocated to the container.</span>
                 </div>
             </label>
-            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. SWAN_projects/requirements.txt, https://github.com/user/env1">
+            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/env1">
+        </div>
+        <br>
+        
+        <div id="customenv_typeSection">
+            <label for="customenv_typeOptions">Custom environment type <a href="#" onclick="toggle_visibility('customenv_typeDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="customenv_typeDetails">
+                    <span class='nb'>Type of custom environment to create. See more in the <a target="_blank" href="https://confluence.cern.ch/display/ACCPY/Getting+started+with+Acc-Py">Acc-Py User guide</a></span>
+                </div>
+            </label>
+            <select id="customenv_typeOptions" name="customenv_type"></select>
+        </div>
+        <br>
+    </div>
+    
+    <div id="resources_config">
+        <h2>Session resources</h2>
+
+        <div id="coresSection">
+            <label for="coresOptions">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="ncoresDetails">
+                    <span class='nb'>Number of cores to associate to the container.</span>
+                </div>
+            </label>
+            <select id="coresOptions" name="ncores"></select>
         </div>
         <br>
 
-        <div id="customenvTypeSection" style="display: block;">
-            <label>Custom environment type <a href="#" onclick="toggle_visibility('customenvDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="customenvDetails">
-                    <span class='nb'>Type of custom environment to create.</span>
+        <div id="memorySection">
+            <label for="memoryOptions">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="memoryDetails">
+                    <span class='nb'>Amount of Memory allocated to the container.</span>
                 </div>
             </label>
-            <br>
-            <input type="radio" id="cvmfsOption" name="customenvType" value="cvmfs" checked onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
-            <label for="cvmfsOption" style="margin-right: 5%;">CVMFS Python</label>
-            <input type="radio" id="accpyOption" name="customenvType" value="accpy" onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
-            <label for="accpyOption" style="margin-right: 5%;">Acc-Py</label>
-            <input type="radio" id="otherOption" name="customenvType" value="custom_python" onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
-            <label for="otherOption" style="margin-right: 5%;">Other</label>
-        </div>
-        <br>
-        <div id="accpySection" style="display: none;">
-            <label for="accpyOptions">Acc-Py version <a href="#" onclick="toggle_visibility('accpyDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="accpyDetails">
-                    <span class='nb'>Version for Acc-Py. See more in the <a target="_blank" href="https://confluence.cern.ch/display/ACCPY/Getting+started+with+Acc-Py">Acc-Py User guide</a></span>
-                </div>
-            </label>
-            <select id="accpyOptions" name="accpy_version"></select>
-        </div>
-        <div id="pythonSection" style="display: none;">
-            <label for="pythonOption">Python path <a href="#" onclick="toggle_visibility('pythonDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="pythonDetails">
-                    <span class='nb'>Path for an alternative Python binary</span>
-                </div>
-            </label>
-            <input type="text" id="pythonOption" name="custom_python" placeholder="e.g. /usr/bin/python3">
+            <select id="memoryOptions" name="memory"></select>
         </div>
         <br>
     </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -330,7 +330,7 @@
         <div id="coresSection">
             <label for="coresOptions">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="ncoresDetails">
-                    <span class='nb'>Number of cores to associate to the container.</span>
+                    <span class='nb'>Amount of cores allocated to the container.</span>
                 </div>
             </label>
             <select id="coresOptions" name="ncores"></select>
@@ -340,7 +340,7 @@
         <div id="memorySection">
             <label for="memoryOptions">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="memoryDetails">
-                    <span class='nb'>Amount of Memory allocated to the container.</span>
+                    <span class='nb'>Amount of memory allocated to the container.</span>
                 </div>
             </label>
             <select id="memoryOptions" name="memory"></select>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -46,7 +46,8 @@
     /*
      * Selects AlmaLinux 9 in the LCG plataform options
      */
-    function selectAlma9(selector) {
+    function selectAlma9(id) {
+        var selector = document.getElementById(id);
         for (var i = 0; i < selector.options.length; i++) {
             if (selector.options[i].text.startsWith('AlmaLinux 9')) {
                 selector.options[i].selected = true;
@@ -58,7 +59,8 @@
     /*
     * Selects default LCG release (105)
     */
-   function selectDefaultLCG(selector) {
+   function selectDefaultLCG(id) {
+        var selector = document.getElementById(id);
         for (var i = 0; i < selector.options.length; i++) {
             if (selector.options[i].value === 'LCG_105_swan') {
                 selector.options[i].selected = true;
@@ -255,15 +257,14 @@
     /**
      * Modifies the some elements according to the selected type of configuration (LCG or Custom Environments)
      */
-    function adjust_customenv() {
+    function toggle_forms() {
         var lcgOption = document.getElementById('lcgOption');
         var customenvOption = document.getElementById('customenvOption');
         
         var customenv_config = document.getElementById('customenv_config');
         var external_config = document.getElementById('external_config');
         var software_config = document.getElementById('software_config');
-        var lcgReleaseOptions = document.getElementById('lcgReleaseOptions');
-        var platformOptions = document.getElementById('platformOptions');
+        var autoenvOption = document.getElementById('autoenvOption');
         
         if (lcgOption.checked) {
             software_config.style.display = 'block';
@@ -272,9 +273,9 @@
             adjust_form();
             adjust_spark();
         } else if (customenvOption.checked) {
-            selectDefaultLCG(lcgReleaseOptions);
+            selectDefaultLCG('lcgReleaseOptions');
             adjust_form();
-            selectAlma9(platformOptions);
+            selectAlma9('platformOptions');
             software_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_config.style.display = 'none';
@@ -471,7 +472,12 @@
                     <span class='nb'>Amount of memory allocated to the container.</span>
                 </div>
             </label>
-            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/env1">
+            <br>
+            <select id="requirements_dropdown" name="requirements_type" style="width: auto; height: auto; display: inline-block; border: 1px solid #ccc; background-color: #f7f7f7;">
+                  <option value="git">Git</option>
+                  <option value="cernbox">CERNBox</option>
+            </select>
+            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/env1" style="width: max-content; height: auto; display: inline-block;">
         </div>
         <br>
         
@@ -482,6 +488,15 @@
                 </div>
             </label>
             <select id="customenv_typeOptions" name="customenv_type"></select>
+        </div>
+        <br>
+        <div id="autoenvSection">
+            <input type="checkbox" id="autoenvOption" name="autoenv" checked style="width: auto; height: auto; display: inline-block;">
+            <label for="autoenvOption" style="margin-right: 5%;">Automatically activation <a href="#" onclick="toggle_visibility('autoenvDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="autoenvDetails">
+                    <span class='nb'>Automatically activates the environment when opening the terminal.</span>
+                </div>
+            </label>
         </div>
         <br>
     </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -40,13 +40,13 @@
         }
         selector.setAttribute('disabled', '');
     }
-    
+
     /*
     * Selects default LCG release (105)
     */
    function selectDefaultLCG(selector) {
         for (var i = 0; i < selector.options.length; i++) {
-           if (selector.options[i].value === '105') {
+            if (selector.options[i].value === 'LCG_105_swan') {
                selector.options[i].selected = true;
                break;
             }
@@ -212,14 +212,14 @@
         selectAccpy.selectedIndex = 0;
     }
 
+    /**
+     * Modifies the some elements according to the selected type of configuration (LCG or Custom Environments)
+     */
     function adjust_customenv() {
-        adjust_form();
         var lcgOption = document.getElementById('lcgOption');
         var customenvOption = document.getElementById('customenvOption');
-        
         var customenv_config = document.getElementById('customenv_config');
         var external_config = document.getElementById('external_config');
-        
         var lcgSection = document.getElementById('lcgSection');
         var lcgReleaseOptions = document.getElementById('lcgReleaseOptions');
         var platformOptions = document.getElementById('platformOptions');
@@ -232,16 +232,21 @@
             lcgReleaseOptions.selectedIndex = 1;
             platformOptions.selectedIndex = 0;
             platformOptions.removeAttribute('disabled');
+            adjust_form();
             adjust_spark();
         } else if (customenvOption.checked ) {
+            selectDefaultLCG(lcgReleaseOptions);
+            adjust_form();
+            selectAlma9(platformOptions);
             customenv_config.style.display = 'block';
             external_config.style.display = 'none';
-            selectDefaultLCG(lcgReleaseOptions);
-            selectAlma9(platformOptions);
             adjust_accpy();
         } 
     }
 
+    /**
+     * Modifies the some elements according to the selected Acc-Py version
+     */
     function adjust_accpy() {
         var accpyOption = document.getElementById('accpyOption');
         var cvmfsOption = document.getElementById('cvmfsOption');
@@ -296,9 +301,9 @@
             </div>
         </label>
         <br>
-        <input type="radio" id="lcgOption" name="configType" value="lcg" checked onclick="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
+        <input type="radio" id="lcgOption" name="configType" value="lcg" checked onchange="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
         <label for="lcgOption" style="margin-right: 5%;">LCG</label>
-        <input type="radio" id="customenvOption" name="configType" value="customenv" onclick="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
+        <input type="radio" id="customenvOption" name="configType" value="customenv" onchange="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
         <label for="customenvOption">Custom Environment</label>
     </div>
     <br>
@@ -374,7 +379,7 @@
                     <span class='nb'>Path to a requirements file stored in your <a target="_blank" href="https://cernbox.cern.ch/">CERNBox</a>, or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
                 </div>
             </label>
-            <input type="text" id="requirementsOption" name="req" placeholder="e.g. SWAN_projects/requirements.txt, https://github.com/user/env1">
+            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. SWAN_projects/requirements.txt, https://github.com/user/env1">
         </div>
         <br>
 
@@ -385,16 +390,16 @@
                 </div>
             </label>
             <br>
-            <input type="radio" id="cvmfsOption" name="customenvType" value="cvmfs" checked onclick="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
+            <input type="radio" id="cvmfsOption" name="customenvType" value="cvmfs" checked onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
             <label for="cvmfsOption" style="margin-right: 5%;">CVMFS Python</label>
-            <input type="radio" id="accpyOption" name="customenvType" value="accpy" onclick="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
+            <input type="radio" id="accpyOption" name="customenvType" value="accpy" onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
             <label for="accpyOption" style="margin-right: 5%;">Acc-Py</label>
-            <input type="radio" id="otherOption" name="customenvType" value="custom_python" onclick="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
+            <input type="radio" id="otherOption" name="customenvType" value="custom_python" onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
             <label for="otherOption" style="margin-right: 5%;">Other</label>
         </div>
         <br>
         <div id="accpySection" style="display: none;">
-            <label for="accpyOptions">Acc-Py Version <a href="#" onclick="toggle_visibility('accpyDetails');"><span class='nbs'>more...</span></a>
+            <label for="accpyOptions">Acc-Py version <a href="#" onclick="toggle_visibility('accpyDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="accpyDetails">
                     <span class='nb'>Version for Acc-Py. See more in the <a target="_blank" href="https://confluence.cern.ch/display/ACCPY/Getting+started+with+Acc-Py">Acc-Py User guide</a></span>
                 </div>
@@ -407,7 +412,7 @@
                     <span class='nb'>Path for an alternative Python binary</span>
                 </div>
             </label>
-            <input type="text" id="pythonOption" name="accpy_version" placeholder="e.g. /usr/bin/python3">
+            <input type="text" id="pythonOption" name="custom_python" placeholder="e.g. /usr/bin/python3">
         </div>
         <br>
     </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -207,7 +207,7 @@
      * Adjusts the width of the repository type dropdown element based on the selected option
      */
     function adjust_repository_dropdown() {
-        const selectElement = document.getElementById('repository_type_dropdown');
+        const selectElement = document.getElementById('repo_type_dropdown');
         const selectedOptionText = selectElement.options[selectElement.selectedIndex].text;
         const tempElement = document.createElement('span');
         tempElement.style.visibility = 'hidden';
@@ -347,7 +347,7 @@
             </label>
             <br>
             <div style="display: flex;">
-                <select id="repository_type_dropdown" name="repo_type" onchange="adjust_repository_dropdown();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
+                <select id="repo_type_dropdown" name="repo_type" onchange="adjust_repository_dropdown();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
                     <option value="eos">EOS</option>
                     <option value="git">Git</option>
                 </select>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -210,20 +210,44 @@
     }
 
     /**
-     * Modifies the selection of Spark clusters depending on the chosen platform
+     * Modifies the selection of Spark clusters and enables users to choose
+     * to use the JupyterLab interface depending on the chosen platform
      */
-    function adjust_spark() {
+    function adjust_options() {
         var platformOptions = document.getElementById('platformOptions');
         var clusterOptions  = document.getElementById('clusterOptions');
+        var jupyterLabOption = document.getElementById("use-jupyterlab");
+
+        /**
+         * Store the chosen platform in a hidden form field, as disabled fields
+         * are not sent in the request
+         */ 
+        var hiddenPlatformOptions = document.getElementById('hiddenPlatformOptions');
 
         var isAlma = platformOptions.selectedOptions[0].text.startsWith('AlmaLinux 9');
 
         if (isAlma) {
-            // On Alma9, make sure cluster selection is enabled
+            /* On Alma9, make sure cluster selection is enabled and that users can
+            select the JupyterLab interface */
             clusterOptions.removeAttribute('disabled');
+            jupyterLabOption.removeAttribute('disabled');
         } else {
             clusterOptions.setAttribute('disabled', '');
             clusterOptions.selectedIndex = 0;
+            jupyterLabOption.setAttribute('disabled', '');
+        }
+
+        hiddenPlatformOptions.value = platformOptions.value;
+    }
+
+    function adjust_platforms() {
+        var platformOptions = document.getElementById('platformOptions');
+        var jupyterLabOption = document.getElementById('use-jupyterlab');
+
+        if (jupyterLabOption.checked) {
+            platformOptions.setAttribute('disabled', '');
+        } else {
+            platformOptions.removeAttribute('disabled');
         }
     }
 
@@ -236,7 +260,7 @@
     <span class='nb' id="optionsHeader">Specify the configuration parameters for the SWAN container that will be created for you.</span>
     </label>
     <label for="alma9">
-    <span class='news' id="alma9">Try out our new experimental interface based on <b>JupyterLab</b>!</span>
+    <span class='news' id="alma9">Try out our new experimental interface based on <b>JupyterLab</b> and let us know your feedback!</span>
     </label>
     <br><br>
 
@@ -254,6 +278,25 @@
         <input type="radio" id="customenvOption" name="software_source" value="customenv" onchange="toggle_form();" style="width: auto; height: auto; display: inline-block;">
         <label for="customenvOption">Custom Environment</label>
         <br><br>
+    <label> User Interface <a href="#" onclick="toggle_visibility('userInterfaceDetails');"><span class='nbs'>more...</span></a></label>
+    <div style="display:none;" id="userInterfaceDetails">
+        <span class='nb'>JupyterLab is the latest web-based interactive development environment for notebooks, code and data. More information <a target="_blank" href="https://jupyterlab.readthedocs.io/en/stable/user/interface.html">here</a>.</span>
+    </div>
+    <div style="display: flex; align-items: center">
+      <input
+        id="use-jupyterlab"
+        type="checkbox"
+        name="use-jupyterlab"
+        value="checked"
+        style="display: inline; width: initial; margin: 0 8px 0 0"
+        onchange="adjust_platforms();"
+      />
+      <span> Try the new JupyterLab interface (experimental)</span>
+    </div>
+    <br>
+    <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="lcgReleaseDetails">
+       <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
     </div>
     
     <!-- LCG configuration -->
@@ -319,6 +362,13 @@
             <select id="builderOptions" name="builder"></select>
         </div>
         <br>
+    </label>
+    <select id="platformOptions" onchange="adjust_options();"></select>
+    <input type="hidden" id="hiddenPlatformOptions" name="platform">
+    <br>
+    <label for="scriptenvOption">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="scriptenvDetails">
+       <span class='nb'>User-provided bash script to define custom environment variables. The variable CERNBOX_HOME is resolved to the proper /eos/user/u/username directory.</span>
     </div>
     
     <!-- Resources configuration -->

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -48,7 +48,8 @@
     /*
      * Selects AlmaLinux 9 in the LCG plataform options
      */
-    function selectAlma9(selector) {
+    function selectAlma9(id) {
+        var selector = document.getElementById(id);
         for (var i = 0; i < selector.options.length; i++) {
             if (selector.options[i].text.startsWith('AlmaLinux 9')) {
                 selector.options[i].selected = true;
@@ -60,7 +61,8 @@
     /*
     * Selects default LCG release (105)
     */
-   function selectDefaultLCG(selector) {
+   function selectDefaultLCG(id) {
+        var selector = document.getElementById(id);
         for (var i = 0; i < selector.options.length; i++) {
             if (selector.options[i].value === 'LCG_105_swan') {
                 selector.options[i].selected = true;
@@ -235,15 +237,14 @@
     /**
      * Modifies the some elements according to the selected type of configuration (LCG or Custom Environments)
      */
-    function adjust_customenv() {
+    function toggle_forms() {
         var lcgOption = document.getElementById('lcgOption');
         var customenvOption = document.getElementById('customenvOption');
         
         var customenv_config = document.getElementById('customenv_config');
         var external_config = document.getElementById('external_config');
         var software_config = document.getElementById('software_config');
-        var lcgReleaseOptions = document.getElementById('lcgReleaseOptions');
-        var platformOptions = document.getElementById('platformOptions');
+        var autoenvOption = document.getElementById('autoenvOption');
         
         if (lcgOption.checked) {
             software_config.style.display = 'block';
@@ -252,9 +253,9 @@
             adjust_form();
             adjust_spark();
         } else if (customenvOption.checked) {
-            selectDefaultLCG(lcgReleaseOptions);
+            selectDefaultLCG('lcgReleaseOptions');
             adjust_form();
-            selectAlma9(platformOptions);
+            selectAlma9('platformOptions');
             software_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_config.style.display = 'none';
@@ -280,7 +281,7 @@
         }
     }
 
-    window.onload = adjust_form;
+    window.onload = toggle_forms;
 //-->
 </script>
 
@@ -301,11 +302,11 @@
             </div>
         </label>
         <br>
-        <input type="radio" id="lcgOption" name="source_type" value="lcg" checked onchange="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
+        <input type="radio" id="lcgOption" name="source_type" value="lcg" checked onchange="toggle_forms();" style="width: auto; height: auto; display: inline-block;">
         <label for="lcgOption" style="margin-right: 5%;">LCG</label>
-        <input type="radio" id="customenvOption" name="source_type" value="customenv" onchange="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
+        <input type="radio" id="customenvOption" name="source_type" value="customenv" onchange="toggle_forms();" style="width: auto; height: auto; display: inline-block;">
         <label for="customenvOption">Custom Environment</label>
-        <br>
+        <br><br>
     </div>
     
     <div id="software_config">
@@ -349,7 +350,12 @@
                     <span class='nb'>Path to a requirements file stored in your <a target="_blank" href="https://cernbox.cern.ch/">CERNBox</a>, or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
                 </div>
             </label>
-            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/env1">
+            <br>
+            <select id="requirements_dropdown" name="requirements_type" style="width: auto; height: auto; display: inline-block; border: 1px solid #ccc; background-color: #f7f7f7;">
+                  <option value="git">Git</option>
+                  <option value="cernbox">CERNBox</option>
+            </select>
+            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/env1" style="width: max-content; height: auto; display: inline-block;">
         </div>
         <br>
         
@@ -360,6 +366,15 @@
                 </div>
             </label>
             <select id="customenv_typeOptions" name="customenv_type"></select>
+        </div>
+        <br>
+        <div id="autoenvSection">
+            <input type="checkbox" id="autoenvOption" name="autoenv" checked style="width: auto; height: auto; display: inline-block;">
+            <label for="autoenvOption" style="margin-right: 5%;">Automatically activation <a href="#" onclick="toggle_visibility('autoenvDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="autoenvDetails">
+                    <span class='nb'>Automatically activates the environment when opening the terminal.</span>
+                </div>
+            </label>
         </div>
         <br>
     </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -80,30 +80,30 @@
             }
         
             // set customenv type options for customenvs
-            const customenvTypes = lcgFormConfig['customenv_options'];
-            var selectCustomenv_type = document.getElementById('customenv_typeOptions');
-            selectCustomenv_type.innerHTML = '';
-            var firstCustomenvTypeSelected = false;
+            const builders = lcgFormConfig['customenv_options'];
+            var selectBuilder = document.getElementById('builderOptions');
+            selectBuilder.innerHTML = '';
+            var firstBuilderSelected = false;
 
-            for( var i = 0 ; i < customenvTypes.length ; i++ ){
-                var customenv_type = customenvTypes[i];
+            for( var i = 0 ; i < builders.length ; i++ ){
+                var builder = builders[i];
 
-                var customenv_typeOption = document.createElement("option");
-                if (customenv_type.type === "label") {
-                    customenv_typeOption.disabled="disabled";
-                    customenv_typeOption.style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0";
-                    customenv_typeOption.value=customenv_type.label.value;
-                    customenv_typeOption.text=customenv_type.label.text;
+                var builderOption = document.createElement("option");
+                if (builder.type === "label") {
+                    builderOption.disabled="disabled";
+                    builderOption.style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0";
+                    builderOption.value=builder.label.value;
+                    builderOption.text=builder.label.text;
                 } else {
-                    if (!firstCustomenvTypeSelected) {
-                        firstCustomenvTypeSelected = true;
-                        customenv_typeOption.selected = true;
+                    if (!firstBuilderSelected) {
+                        firstBuilderSelected = true;
+                        builderOption.selected = true;
                     }
-                    customenv_typeOption.value=customenv_type.builder.value;
-                    customenv_typeOption.text=customenv_type.builder.text;
+                    builderOption.value=builder.builder.value;
+                    builderOption.text=builder.builder.text;
                 }
 
-                selectCustomenv_type.add(customenv_typeOption);
+                selectBuilder.add(builderOption);
             }
         }
 
@@ -353,13 +353,13 @@
         </div>
         <br>
         
-        <div id="customenv_typeSection">
-            <label for="customenv_typeOptions">Type <a href="#" onclick="toggle_visibility('customenv_typeDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="customenv_typeDetails">
-                    <span class='nb'>Type of custom environment to create (generic or community-specific).</a></span>
+        <div id="builderSection">
+            <label for="builderOptions">Builder <a href="#" onclick="toggle_visibility('builderDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="builderDetails">
+                    <span class='nb'>Program responsible for building the custom environment (generic or community-specific).</a></span>
                 </div>
             </label>
-            <select id="customenv_typeOptions" name="customenv_type"></select>
+            <select id="builderOptions" name="builder"></select>
         </div>
         <br>
     </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -6,25 +6,6 @@
 
     var formConfig = {{ options_form_config }};
 
-    const customenv_types = [
-      {
-        "value": "python-python3",
-        "text": "Python 3"
-      },
-      {
-        "value": "accpy-2023.06",
-        "text": "Acc-Py 2023.06"
-      },
-      {
-        "value": "accpy-2021.12",
-        "text": "Acc-Py 2021.12"
-      },
-      {
-        "value": "accpy-2020.11",
-        "text": "Acc-Py 2020.11"
-      }
-    ];
-
     var formInitialized = false;
 
     /**

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -226,7 +226,7 @@
         if (lcgOption.checked) {
             lcg_config.style.display = 'block';
             customenv_config.style.display = 'none';
-            external_config.style.display = 'block';
+            external_res_config.style.display = 'block';
             adjust_spark();
         } else if (customenvOption.checked) {
             selectDefaultLCG('lcgReleaseOptions');
@@ -234,7 +234,7 @@
             selectAlma9('platformOptions');
             software_config.style.display = 'none';
             customenv_config.style.display = 'block';
-            external_config.style.display = 'none';
+            external_res_config.style.display = 'none';
         } 
     }
 

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -38,13 +38,13 @@
         }
         selector.setAttribute('disabled', '');
     }
-    
+
     /*
     * Selects default LCG release (105)
     */
    function selectDefaultLCG(selector) {
         for (var i = 0; i < selector.options.length; i++) {
-           if (selector.options[i].value === '105') {
+            if (selector.options[i].value === 'LCG_105_swan') {
                selector.options[i].selected = true;
                break;
             }
@@ -237,14 +237,14 @@
         } 
     }
 
+    /**
+     * Modifies the some elements according to the selected type of configuration (LCG or Custom Environments)
+     */
     function adjust_customenv() {
-        adjust_form();
         var lcgOption = document.getElementById('lcgOption');
         var customenvOption = document.getElementById('customenvOption');
-        
         var customenv_config = document.getElementById('customenv_config');
         var external_config = document.getElementById('external_config');
-        
         var lcgSection = document.getElementById('lcgSection');
         var lcgReleaseOptions = document.getElementById('lcgReleaseOptions');
         var platformOptions = document.getElementById('platformOptions');
@@ -257,16 +257,21 @@
             lcgReleaseOptions.selectedIndex = 1;
             platformOptions.selectedIndex = 0;
             platformOptions.removeAttribute('disabled');
+            adjust_form();
             adjust_spark();
         } else if (customenvOption.checked ) {
+            selectDefaultLCG(lcgReleaseOptions);
+            adjust_form();
+            selectAlma9(platformOptions);
             customenv_config.style.display = 'block';
             external_config.style.display = 'none';
-            selectDefaultLCG(lcgReleaseOptions);
-            selectAlma9(platformOptions);
             adjust_accpy();
         } 
     }
 
+    /**
+     * Modifies the some elements according to the selected Acc-Py version
+     */
     function adjust_accpy() {
         var accpyOption = document.getElementById('accpyOption');
         var cvmfsOption = document.getElementById('cvmfsOption');
@@ -473,7 +478,40 @@
                     <span class='nb'>Amount of memory allocated to the container.</span>
                 </div>
             </label>
-            <select id="memoryOptions" name="memory"></select>
+            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. SWAN_projects/requirements.txt, https://github.com/user/env1">
+        </div>
+        <br>
+
+        <div id="customenvTypeSection" style="display: block;">
+            <label>Custom environment type <a href="#" onclick="toggle_visibility('customenvDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="customenvDetails">
+                    <span class='nb'>Type of custom environment to create.</span>
+                </div>
+            </label>
+            <br>
+            <input type="radio" id="cvmfsOption" name="customenvType" value="cvmfs" checked onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
+            <label for="cvmfsOption" style="margin-right: 5%;">CVMFS Python</label>
+            <input type="radio" id="accpyOption" name="customenvType" value="accpy" onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
+            <label for="accpyOption" style="margin-right: 5%;">Acc-Py</label>
+            <input type="radio" id="otherOption" name="customenvType" value="custom_python" onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
+            <label for="otherOption" style="margin-right: 5%;">Other</label>
+        </div>
+        <br>
+        <div id="accpySection" style="display: none;">
+            <label for="accpyOptions">Acc-Py version <a href="#" onclick="toggle_visibility('accpyDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="accpyDetails">
+                    <span class='nb'>Version for Acc-Py. See more in the <a target="_blank" href="https://confluence.cern.ch/display/ACCPY/Getting+started+with+Acc-Py">Acc-Py User guide</a></span>
+                </div>
+            </label>
+            <select id="accpyOptions" name="accpy_version"></select>
+        </div>
+        <div id="pythonSection" style="display: none;">
+            <label for="pythonOption">Python path <a href="#" onclick="toggle_visibility('pythonDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="pythonDetails">
+                    <span class='nb'>Path for an alternative Python binary</span>
+                </div>
+            </label>
+            <input type="text" id="pythonOption" name="custom_python" placeholder="e.g. /usr/bin/python3">
         </div>
         <br>
     </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -443,7 +443,7 @@
                     <span class='nb'>Type of custom environment to create (generic or community-specific).</a></span>
                 </div>
             </label>
-            <select id="customenv_typeOptions" name="customenv_type"></select>
+            <select id="builderOptions" name="builder"></select>
         </div>
         <br>
         <div id="autoenvSection">

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -26,35 +26,6 @@
         throw "LCG Data not found"
     }
 
-    /*
-     * Selects AlmaLinux 9 in the LCG plataform options
-     */
-    function selectAlma9() {
-        var selector = document.getElementById('platformOptions');
-        for (var i = 0; i < selector.options.length; i++) {
-            if (selector.options[i].text.startsWith('AlmaLinux 9')) {
-                selector.options[i].selected = true;
-                break;
-            }
-        }
-    }
-
-    /*
-    * Selects default LCG release (first of recommended section)
-    */
-   function selectDefaultLCG() {
-        var selector = document.getElementById('lcgReleaseOptions');
-        var recommend_label = false;
-        for (var i = 0; i < selector.options.length; i++) {
-            if (selector.options[i].text.includes("Recommended"))
-                recommend_label = true;
-            if (recommend_label === true && !selector.options[i].disabled) {
-                selector.options[i].selected = true;
-                break;
-            }
-        }
-    }
-
     /**
      * Enable display of element if previously disabled, and disable if previously enabled
      */
@@ -232,7 +203,7 @@
     /**
      * Adjusts the width of the repository type dropdown element based on the selected option
      */
-    function adjustRepositoryDropdown() {
+    function adjust_repository_dropdown() {
         const selectElement = document.getElementById('repository_type_dropdown');
         const selectedOptionText = selectElement.options[selectElement.selectedIndex].text;
         const tempElement = document.createElement('span');
@@ -264,20 +235,17 @@
         
         var customenv_config = document.getElementById('customenv_config');
         var external_config = document.getElementById('external_config');
-        var software_config = document.getElementById('software_config');
+        var lcg_config = document.getElementById('lcg_config');
         
         if (lcgOption.checked) {
-            software_config.style.display = 'block';
+            lcg_config.style.display = 'block';
             customenv_config.style.display = 'none';
             external_config.style.display = 'block';
             adjust_form();
             adjust_spark();
-        } else { // if customenvOption.checked
-            selectDefaultLCG();
-            adjust_form();
-            selectAlma9();
-            adjustRepositoryDropdown();
-            software_config.style.display = 'none';
+        } else {
+            adjust_repository_dropdown();
+            lcg_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_config.style.display = 'none';
         } 
@@ -315,11 +283,12 @@
     </label>
     <br><br>
 
+    <!-- Source Type selection -->
     <div id="source_typeSection">
         <h2>Software</h2>
         <label>Source <a href="#" onclick="toggle_visibility('sourceDetails');"><span class='nbs'>more...</span></a>
             <div style="display:none;" id="sourceDetails">
-                <span class='nb'>Source type for your container.</span>
+                <span class='nb'>Software source: curated stack (LCG) or custom environment.</span>
             </div>
         </label>
         <br>
@@ -330,11 +299,12 @@
         <br><br>
     </div>
     
-    <div id="software_config">
-        <div id="lcgSection">
+    <!-- LCG configuration -->
+    <div id="lcg_config">
+        <div id="lcgReleaseSection">
             <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="lcgReleaseDetails">
-                    <span class='nb'>Software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
+                    <span class='nb'>LCG release to use as software source. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG releases package info</a> page.</span>
                 </div>
             </label>
             <select id="lcgReleaseOptions" name="LCG-rel" onchange="adjust_form();">
@@ -342,10 +312,10 @@
         </div>
         <br>
         
-        <div id="plataformSection">
+        <div id="platformSection">
             <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="platformDetails">
-                    <span class='nb'>Combination of compiler version and flags.</span>
+                    <span class='nb'>Operating system and compiler version.</span>
                 </div>
             </label>
             <select id="platformOptions" name="platform" onchange="adjust_spark();"></select>
@@ -369,12 +339,12 @@
             <label for="repositoryOption">Repository 
                 <a href="#" onclick="toggle_visibility('repositoryDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="repositoryDetails">
-                    <span class='nb'>Path to a folder stored in your <a target="_blank" href="https://cernbox.cern.ch/">EOS</a> (/eos/user/u/username), or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
+                    <span class='nb'>Repository containing a requirements.txt file. It can be a path on EOS or the URL of a public git repository.</span>
                 </div>
             </label>
             <br>
             <div style="display: flex;">
-                <select id="repository_type_dropdown" name="repository_type" onchange="adjustRepositoryDropdown();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
+                <select id="repository_type_dropdown" name="repository_type" onchange="adjust_repository_dropdown();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
                       <option value="git">Git</option>
                       <option value="eos">EOS</option>
                 </select>
@@ -386,7 +356,7 @@
         <div id="customenv_typeSection">
             <label for="customenv_typeOptions">Type <a href="#" onclick="toggle_visibility('customenv_typeDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="customenv_typeDetails">
-                    <span class='nb'>Type of custom environment to create. See more in the <a target="_blank" href="https://confluence.cern.ch/display/ACCPY/Getting+started+with+Acc-Py">Acc-Py User guide</a></span>
+                    <span class='nb'>Type of custom environment to create (generic or community-specific).</a></span>
                 </div>
             </label>
             <select id="customenv_typeOptions" name="customenv_type"></select>
@@ -394,6 +364,7 @@
         <br>
     </div>
     
+    <!-- Resources configuration -->
     <div id="resources_config">
         <h2>Session resources</h2>
 

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -347,7 +347,7 @@
             </label>
             <br>
             <div style="display: flex;">
-                <select id="repository_type_dropdown" name="repository_type" onchange="adjust_repository_dropdown();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
+                <select id="repository_type_dropdown" name="repo_type" onchange="adjust_repository_dropdown();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
                     <option value="eos">EOS</option>
                     <option value="git">Git</option>
                 </select>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -12,7 +12,7 @@
      * Get Form data dictionary for given selectedValue.
      */
     function findFormData(form, formElement, value) {
-        // Data is taken from from formConfig global variable
+        // Data is taken from formConfig global variable
         var formOptions = formConfig[form];
         for (key in formOptions) {
             const formData = formOptions[key];

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -304,8 +304,8 @@
             <br>
             <div style="display: flex;">
                 <select id="repository_type_dropdown" name="repository_type" onchange="adjust_repository_dropdown();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
-                      <option value="git">Git</option>
-                      <option value="eos">EOS</option>
+                    <option value="eos">EOS</option>
+                    <option value="git">Git</option>
                 </select>
                 <input type="text" id="repositoryOption" name="repository" style="flex-grow: 1; margin-left: 0; border: 1px solid #afafaf;">
             </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -235,22 +235,29 @@
     }
 
     /**
-     * Allows to adjust the width of the select element based on the selected option
+     * Allows to adjust the width of the dropdown element based on the selected option
      */
-    function adjustSelectWidth(id) {
-        const selectElement = document.getElementById(id);
+    function adjustDropdownWidth() {
+        const selectElement = document.getElementById('requirements_dropdown');
         const selectedOptionText = selectElement.options[selectElement.selectedIndex].text;
         const tempElement = document.createElement('span');
         tempElement.style.visibility = 'hidden';
         tempElement.style.whiteSpace = 'nowrap';
         tempElement.style.fontSize = window.getComputedStyle(selectElement).fontSize;
         tempElement.innerHTML = selectedOptionText;
-
+        
         document.body.appendChild(tempElement);
         const width = tempElement.offsetWidth;
         document.body.removeChild(tempElement);
-
+        
         selectElement.style.width = `${width + 50}px`;
+
+        const requirementsOption = document.getElementById('requirementsOption');
+        if (selectElement.value === 'cernbox') {
+            requirementsOption.placeholder = 'e.g. SWAN_projects/myproject';
+        } else if (selectElement.value === 'git') {
+            requirementsOption.placeholder="e.g. https://gitlab.cern.ch/user/myrepo";
+        }
     }
 
     /**
@@ -274,7 +281,7 @@
             selectDefaultLCG('lcgReleaseOptions');
             adjust_form();
             selectAlma9('platformOptions');
-            adjustSelectWidth('requirements_dropdown');
+            adjustDropdownWidth();
             software_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_config.style.display = 'none';
@@ -372,11 +379,11 @@
             </label>
             <br>
             <div style="display: flex;">
-                <select id="requirements_dropdown" name="requirements_type" onchange="adjustSelectWidth('requirements_dropdown');" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
+                <select id="requirements_dropdown" name="requirements_type" onchange="adjustDropdownWidth();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
                       <option value="git">Git</option>
                       <option value="cernbox">CERNBox</option>
                 </select>
-                <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/repo_env" style="flex-grow: 1; margin-left: 0; border: 1px solid #afafaf;">
+                <input type="text" id="requirementsOption" name="requirements" style="flex-grow: 1; margin-left: 0; border: 1px solid #afafaf;">
             </div>
         </div>
         <br>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -347,7 +347,7 @@
         <div id="requirementsSection">
             <label for="requirementsOption">Git Repository <a href="#" onclick="toggle_visibility('requirementsDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="requirementsDetails">
-                    <span class='nb'>Path to a requirements file stored in your <a target="_blank" href="https://cernbox.cern.ch/">CERNBox</a>, or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
+                    <span class='nb'>Path to a folder stored in your <a target="_blank" href="https://cernbox.cern.ch/">CERNBox</a>, or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
                 </div>
             </label>
             <br>
@@ -355,7 +355,7 @@
                   <option value="git">Git</option>
                   <option value="cernbox">CERNBox</option>
             </select>
-            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/env1" style="width: max-content; height: auto; display: inline-block;">
+            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/repo_env" style="width: 72%; height: auto; display: inline-block;">
         </div>
         <br>
         

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -24,32 +24,6 @@
         throw `${formElement} Data not found`
     }
 
-    /*
-     * Selects AlmaLinux 9 in the LCG plataform options
-     */
-    function selectAlma9(id) {
-        var selector = document.getElementById(id);
-        for (var i = 0; i < selector.options.length; i++) {
-            if (selector.options[i].text.startsWith('AlmaLinux 9')) {
-                selector.options[i].selected = true;
-                break;
-            }
-        }
-    }
-
-    /*
-    * Selects default LCG release (105)
-    */
-   function selectDefaultLCG(id) {
-        var selector = document.getElementById(id);
-        for (var i = 0; i < selector.options.length; i++) {
-            if (selector.options[i].value === 'LCG_105_swan') {
-                selector.options[i].selected = true;
-                break;
-            }
-        }
-    }
-
     /**
      * Enable display of element if previously disabled, and disable if previously enabled
      */
@@ -246,9 +220,10 @@
         var external_config = document.getElementById('external_config');
         var software_config = document.getElementById('software_config');
         var autoenvOption = document.getElementById('autoenvOption');
+        var lcg_config = document.getElementById('lcg_config');
         
         if (lcgOption.checked) {
-            software_config.style.display = 'block';
+            lcg_config.style.display = 'block';
             customenv_config.style.display = 'none';
             external_config.style.display = 'block';
             adjust_form();
@@ -465,7 +440,7 @@
         <div id="customenv_typeSection">
             <label for="customenv_typeOptions">Custom environment type <a href="#" onclick="toggle_visibility('customenv_typeDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="customenv_typeDetails">
-                    <span class='nb'>Type of custom environment to create. See more in the <a target="_blank" href="https://confluence.cern.ch/display/ACCPY/Getting+started+with+Acc-Py">Acc-Py User guide</a></span>
+                    <span class='nb'>Type of custom environment to create (generic or community-specific).</a></span>
                 </div>
             </label>
             <select id="customenv_typeOptions" name="customenv_type"></select>
@@ -482,6 +457,7 @@
         <br>
     </div>
     
+    <!-- Resources configuration -->
     <div id="resources_config">
         <h2>Session resources</h2>
 

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -221,12 +221,12 @@
         var software_config = document.getElementById('software_config');
         var autoenvOption = document.getElementById('autoenvOption');
         var lcg_config = document.getElementById('lcg_config');
-        
+
+        adjust_form();
         if (lcgOption.checked) {
             lcg_config.style.display = 'block';
             customenv_config.style.display = 'none';
             external_config.style.display = 'block';
-            adjust_form();
             adjust_spark();
         } else if (customenvOption.checked) {
             selectDefaultLCG('lcgReleaseOptions');

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -72,6 +72,7 @@
                 optionsHeader.innerHTML = header;
             }
 
+            // Loop through all source types and populate the main dropdown options (lcg -> lcg_release, customenv -> builder)
             for (var source in sourceConfig) {
                 const currentSource = sourceConfig[source];
                 const formOptions = formConfig[currentSource.sourceForm];
@@ -120,6 +121,7 @@
             ]
         };
 
+        // Populate the form according to main dropdown selection
         available_configs[selectedSource].forEach(function(config) {
             var configElement = document.getElementById(config.elementName);
             configElement.innerHTML = '';
@@ -172,20 +174,20 @@
         var lcgOption = document.getElementById('lcgOption');
 
         var customenv_config = document.getElementById('customenv_config');
-        var external_config = document.getElementById('external_config');
+        var external_res_config = document.getElementById('external_res_config');
         var lcg_config = document.getElementById('lcg_config');
 
         adjust_form();
         if (lcgOption.checked) {
             lcg_config.style.display = 'block';
             customenv_config.style.display = 'none';
-            external_config.style.display = 'block';
+            external_res_config.style.display = 'block';
             adjust_spark();
         } else {
             adjust_repository_dropdown();
             lcg_config.style.display = 'none';
             customenv_config.style.display = 'block';
-            external_config.style.display = 'none';
+            external_res_config.style.display = 'none';
         } 
     }
 
@@ -347,7 +349,7 @@
     </div>
 
     <!-- External computing resources -->
-    <div id="external_config" style="display: block;">
+    <div id="external_res_config" style="display: block;">
         <h2>External computing resources</h2>
         
         <div id="clusterSection">

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -253,10 +253,10 @@
         selectElement.style.width = `${width + 50}px`;
 
         const requirementsOption = document.getElementById('requirementsOption');
-        if (selectElement.value === 'cernbox') {
-            requirementsOption.placeholder = 'e.g. SWAN_projects/myproject';
+        if (selectElement.value === 'eos') {
+            requirementsOption.placeholder = 'e.g. $CERNBOX_HOME/MySWAN';
         } else if (selectElement.value === 'git') {
-            requirementsOption.placeholder="e.g. https://gitlab.cern.ch/user/myrepo";
+            requirementsOption.placeholder= "e.g. https://gitlab.cern.ch/user/myrepo";
         }
     }
 
@@ -374,14 +374,14 @@
             <label for="requirementsOption">Repository 
                 <a href="#" onclick="toggle_visibility('requirementsDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="requirementsDetails">
-                    <span class='nb'>Path to a folder stored in your <a target="_blank" href="https://cernbox.cern.ch/">CERNBox</a>, or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
+                    <span class='nb'>Path to a folder stored in your <a target="_blank" href="https://cernbox.cern.ch/">EOS</a> (/eos/user/u/username), or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
                 </div>
             </label>
             <br>
             <div style="display: flex;">
                 <select id="requirements_dropdown" name="requirements_type" onchange="adjustDropdownWidth();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
                       <option value="git">Git</option>
-                      <option value="cernbox">CERNBox</option>
+                      <option value="eos">EOS</option>
                 </select>
                 <input type="text" id="requirementsOption" name="requirements" style="flex-grow: 1; margin-left: 0; border: 1px solid #afafaf;">
             </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -4,26 +4,24 @@
 <script type="text/javascript">
 <!--
 
-    var lcgFormConfig = {{ options_form_config }};
+    var formConfig = {{ options_form_config }};
 
     var formInitialized = false;
 
     /**
-     * Get LCG data dictionary for given lcgValue.
+     * Get Form data dictionary for given selectedValue.
      */
-    function findLcgData(lcgValue) {
-        var lcgData;
-
-        // Data is taken from from lcgFormConfig global variable
-        var lcgFormOptions = lcgFormConfig['lcg_options'];
-        for (key in lcgFormOptions) {
-            lcgData = lcgFormOptions[key];
-            if (lcgData.type === "selection" && lcgData.lcg.value === lcgValue) {
-                return lcgData;
+    function findFormData(form, formElement, value) {
+        // Data is taken from from formConfig global variable
+        var formOptions = formConfig[form];
+        for (key in formOptions) {
+            const formData = formOptions[key];
+            if (formData.type === "selection" && formData[formElement].value === value) {
+                return formData;
             }
         }
 
-        throw "LCG Data not found"
+        throw `${formElement} Data not found`
     }
 
     /**
@@ -41,7 +39,27 @@
      * Renders a form based on config file
      */
     function adjust_form() {
-        var selectLCG = document.getElementById('lcgReleaseOptions');
+        const sourceOptions = document.getElementsByName('source_type');
+        let selectedSource = null;
+        for (let i = 0; i < sourceOptions.length; i++) {
+            if (sourceOptions[i].checked) {
+                selectedSource = sourceOptions[i].value;
+                break;
+            }
+        }
+
+        var sourceConfig = {
+            lcg: {
+                optionsElement: document.getElementById("lcgReleaseOptions"),
+                sourceForm: "lcg_options",
+                formElement: "lcg",
+            },
+            customenv: {
+                optionsElement: document.getElementById("builderOptions"),
+                sourceForm: "customenv_options",
+                formElement: "builder",
+            }
+        };
 
         // if form has not been yet initialized, initialize
         if (!formInitialized) {
@@ -49,159 +67,76 @@
 
             // set proper header for the whole form based on config
             var optionsHeader = document.getElementById('optionsHeader');
-            var header = lcgFormConfig['header'];
+            var header = formConfig['header'];
             if (header) {
                 optionsHeader.innerHTML = header;
             }
 
-            // set LCG option in the rendered form - first LCG is default
-            const lcgFormOptions = lcgFormConfig['lcg_options'];
-            selectLCG.innerHTML = '';
-            var firstLCGSelected = false;
-            for( var i = 0 ; i < lcgFormOptions.length ; i++ ){
-                var lcgFormEntry = lcgFormOptions[i];
+            for (var source in sourceConfig) {
+                const currentSource = sourceConfig[source];
+                const formOptions = formConfig[currentSource.sourceForm];
+                currentSource.optionsElement.innerHTML = '';
+                var firstFormOptionselected = false;
 
-                var selectLCGOption = document.createElement("option");
-                if (lcgFormEntry.type === "label") {
-                    selectLCGOption.disabled="disabled";
-                    selectLCGOption.style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0";
-                    selectLCGOption.value=lcgFormEntry.label.value;
-                    selectLCGOption.text=lcgFormEntry.label.text;
-                } else {
-                    if (!firstLCGSelected) {
-                        firstLCGSelected = true;
-                        selectLCGOption.selected = true;
+                for( var i = 0 ; i < formOptions.length ; i++ ){
+                    var formEntry = formOptions[i];
+                    var formOption = document.createElement("option");
+
+                    if (formEntry.type === "label") {
+                        formOption.disabled = "disabled";
+                        formOption.style = "border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0";
+                        formOption.value = formEntry.label.value;
+                        formOption.text = formEntry.label.text;
+                    } else {
+                        if (!firstFormOptionselected) {
+                            firstFormOptionselected = true;
+                            formOption.selected = true;
+                        }
+                        formOption.value = formEntry[currentSource.formElement].value;
+                        formOption.text = formEntry[currentSource.formElement].text;
                     }
-                    selectLCGOption.value=lcgFormEntry.lcg.value;
-                    selectLCGOption.text=lcgFormEntry.lcg.text;
+
+                    currentSource.optionsElement.add(formOption);
+                }
+            }
+        }
+
+        // get currently selected source and extract its configuration (formData)
+        const selectedConfig = sourceConfig[selectedSource];
+        var selectedValue = selectedConfig.optionsElement.value;
+        var formData = findFormData(selectedConfig.sourceForm, selectedConfig.formElement, selectedValue);
+
+        var available_configs = {
+            'lcg': [
+                {elementName: 'platformOptions', formKey: "platforms"}, 
+                {elementName: 'coresOptions', formKey: "cores"}, 
+                {elementName: 'memoryOptions', formKey: "memory"}, 
+                {elementName: 'clusterOptions', formKey: "clusters"}, 
+                {elementName: 'condorOptions', formKey: "condor"}
+            ],
+            'customenv': [
+                {elementName: 'coresOptions', formKey: "cores"},
+                {elementName: 'memoryOptions', formKey: "memory"}
+            ]
+        };
+
+        available_configs[selectedSource].forEach(function(config) {
+            var configElement = document.getElementById(config.elementName);
+            configElement.innerHTML = '';
+
+            for( var i = 0 ; i < formData[config.formKey].length ; i++ ){
+                var formOption = formData[config.formKey][i];
+
+                var selectOption = document.createElement("option");
+                selectOption.value = formOption.value;
+                selectOption.text = formOption.text;
+                if (i === 0) {
+                    selectOption.selected = true;
                 }
 
-                selectLCG.add(selectLCGOption);
+                configElement.add(selectOption);
             }
-        
-            // set customenv type options for customenvs
-            const builders = lcgFormConfig['customenv_options'];
-            var selectBuilder = document.getElementById('builderOptions');
-            selectBuilder.innerHTML = '';
-            var firstBuilderSelected = false;
-
-            for( var i = 0 ; i < builders.length ; i++ ){
-                var builder = builders[i];
-
-                var builderOption = document.createElement("option");
-                if (builder.type === "label") {
-                    builderOption.disabled="disabled";
-                    builderOption.style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0";
-                    builderOption.value=builder.label.value;
-                    builderOption.text=builder.label.text;
-                } else {
-                    if (!firstBuilderSelected) {
-                        firstBuilderSelected = true;
-                        builderOption.selected = true;
-                    }
-                    builderOption.value=builder.builder.value;
-                    builderOption.text=builder.builder.text;
-                }
-
-                selectBuilder.add(builderOption);
-            }
-        }
-
-        // get currently selected LCG and extract that lcg configuration (lcgData)
-        var lcgValue = selectLCG.value;
-        var lcgData = findLcgData(lcgValue);
-
-        // adjust platforms option for lcg
-        var selectPlatform = document.getElementById('platformOptions');
-        selectPlatform.innerHTML = '';
-
-        for( var i = 0 ; i < lcgData.platforms.length ; i++ ){
-            var lcgPlatform = lcgData.platforms[i];
-
-            var selectPlatformOption = document.createElement("option");
-            selectPlatformOption.value = lcgPlatform.value;
-            selectPlatformOption.text = lcgPlatform.text;
-            if (i === 0) {
-                selectPlatformOption.selected = true;
-            }
-
-            selectPlatform.add(selectPlatformOption);
-        }
-
-        // adjust cores option for lcg
-        var selectCores = document.getElementById('coresOptions');
-        selectCores.innerHTML = '';
-
-        for( var i = 0 ; i < lcgData.cores.length ; i++ ){
-            var lcgCores = lcgData.cores[i];
-
-            var selectCoresOption = document.createElement("option");
-            selectCoresOption.value = lcgCores.value;
-            selectCoresOption.text = lcgCores.text;
-            if (i === 0) {
-                selectCoresOption.selected = true;
-            }
-
-            selectCores.add(selectCoresOption);
-        }
-
-        // adjust memory option for lcg
-        var selectMemory = document.getElementById('memoryOptions');
-        selectMemory.innerHTML = '';
-
-        for( var i = 0 ; i < lcgData.memory.length ; i++ ){
-            var lcgMemory = lcgData.memory[i];
-
-            var selectMemoryOption = document.createElement("option");
-            selectMemoryOption.value = lcgMemory.value;
-            selectMemoryOption.text = lcgMemory.text;
-            if (i === 0) {
-                selectMemoryOption.selected = true;
-            }
-
-            selectMemory.add(selectMemoryOption);
-        }
-
-        // adjust clusters option for lcg
-        var selectCluster = document.getElementById('clusterOptions');
-        selectCluster.innerHTML = '';
-        // Make sure Spark cluster options are enabled on LCG release change
-        selectCluster.removeAttribute('disabled');
-
-        for( var i = 0 ; i < lcgData.clusters.length ; i++ ){
-            var lcgCluster = lcgData.clusters[i];
-
-            if (lcgCluster.value === "k8s" || lcgCluster.value === "hadoop-qa") {
-                continue;
-            }
-
-            var selectClusterOption = document.createElement("option");
-            selectClusterOption.value = lcgCluster.value;
-            selectClusterOption.text = lcgCluster.text;
-            if (i === 0) {
-                selectClusterOption.selected = true;
-            }
-
-            selectCluster.add(selectClusterOption);
-        }
-
-        // adjust condor option for lcg
-        var selectCondor = document.getElementById('condorOptions');
-        selectCondor.innerHTML = '';
-
-        for( var i = 0 ; i < lcgData.condor.length ; i++ ){
-            var lcgCondor = lcgData.condor[i];
-
-            var selectCondorOption = document.createElement("option");
-            selectCondorOption.value = lcgCondor.value;
-            selectCondorOption.text = lcgCondor.text;
-            if (i === 0) {
-                selectCondorOption.selected = true;
-            }
-
-            selectCondor.add(selectCondorOption);
-        }
-
+        });
     }
 
     /**
@@ -235,17 +170,16 @@
      */
     function toggle_form() {
         var lcgOption = document.getElementById('lcgOption');
-        var customenvOption = document.getElementById('customenvOption');
-        
+
         var customenv_config = document.getElementById('customenv_config');
         var external_config = document.getElementById('external_config');
         var lcg_config = document.getElementById('lcg_config');
-        
+
+        adjust_form();
         if (lcgOption.checked) {
             lcg_config.style.display = 'block';
             customenv_config.style.display = 'none';
             external_config.style.display = 'block';
-            adjust_form();
             adjust_spark();
         } else {
             adjust_repository_dropdown();

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -209,41 +209,22 @@
         } 
     }
 
+    
     /**
      * Modifies the selection of Spark clusters depending on the chosen platform
      */
     function adjust_spark() {
         var platformOptions = document.getElementById('platformOptions');
-
-        function removeCluster(cluster) {
-            var clusterOptions  = document.getElementById('clusterOptions');
-            for (var i = 0; i < clusterOptions.options.length; i++) {
-                if (clusterOptions.options[i].value === cluster) {
-                    clusterOptions.remove(i);
-                    break;
-                }
-            }
-        }
-
-        function addCluster(clusterValue, clusterName) {
-            var selectClusterOption = document.createElement("option");
-            selectClusterOption.value = clusterValue;
-            selectClusterOption.text = clusterName;
-            clusterOptions.add(selectClusterOption);
-        }
+        var clusterOptions  = document.getElementById('clusterOptions');
 
         var isAlma = platformOptions.selectedOptions[0].text.startsWith('AlmaLinux 9');
 
         if (isAlma) {
+            // On Alma9, make sure cluster selection is enabled
+            clusterOptions.removeAttribute('disabled');
+        } else {
+            clusterOptions.setAttribute('disabled', '');
             clusterOptions.selectedIndex = 0;
-            removeCluster("analytix")
-            addCluster("k8s", "Cloud Containers (K8s)")
-            addCluster("hadoop-qa", "QA")
-        }
-        else {
-            addCluster("analytix", "General Purpose (Analytix)")
-            removeCluster("k8s")
-            removeCluster("hadoop-qa")
         }
     }
 

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -209,7 +209,6 @@
         } 
     }
 
-    
     /**
      * Modifies the selection of Spark clusters depending on the chosen platform
      */
@@ -237,7 +236,7 @@
     <span class='nb' id="optionsHeader">Specify the configuration parameters for the SWAN container that will be created for you.</span>
     </label>
     <label for="alma9">
-    <span class='news' id="alma9">Select <b>AlmaLinux 9</b> as Platform to try out our new experimental Alma9 image with <b>JupyterLab</b> as default interface! More information <a target="_blank" href="https://swan.docs.cern.ch/alma9/">here</a>.</span>
+    <span class='news' id="alma9">Try out our new experimental interface based on <b>JupyterLab</b>!</span>
     </label>
     <br><br>
 

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -9,7 +9,7 @@
     const customenv_types = [
       {
         "value": "python-python3",
-        "text": "Python 3"
+        "text": "Generic"
       },
       {
         "value": "accpy-2023.06",
@@ -235,6 +235,25 @@
     }
 
     /**
+     * Allows to adjust the width of the select element based on the selected option
+     */
+    function adjustSelectWidth(id) {
+        const selectElement = document.getElementById(id);
+        const selectedOptionText = selectElement.options[selectElement.selectedIndex].text;
+        const tempElement = document.createElement('span');
+        tempElement.style.visibility = 'hidden';
+        tempElement.style.whiteSpace = 'nowrap';
+        tempElement.style.fontSize = window.getComputedStyle(selectElement).fontSize;
+        tempElement.innerHTML = selectedOptionText;
+
+        document.body.appendChild(tempElement);
+        const width = tempElement.offsetWidth;
+        document.body.removeChild(tempElement);
+
+        selectElement.style.width = `${width + 50}px`;
+    }
+
+    /**
      * Modifies the some elements according to the selected type of configuration (LCG or Custom Environments)
      */
     function toggle_forms() {
@@ -244,7 +263,6 @@
         var customenv_config = document.getElementById('customenv_config');
         var external_config = document.getElementById('external_config');
         var software_config = document.getElementById('software_config');
-        var autoenvOption = document.getElementById('autoenvOption');
         
         if (lcgOption.checked) {
             software_config.style.display = 'block';
@@ -256,6 +274,7 @@
             selectDefaultLCG('lcgReleaseOptions');
             adjust_form();
             selectAlma9('platformOptions');
+            adjustSelectWidth('requirements_dropdown');
             software_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_config.style.display = 'none';
@@ -345,36 +364,30 @@
     <!-- Custom environment configuration -->
     <div id="customenv_config" style="display: none;">
         <div id="requirementsSection">
-            <label for="requirementsOption">Git Repository <a href="#" onclick="toggle_visibility('requirementsDetails');"><span class='nbs'>more...</span></a>
+            <label for="requirementsOption">Repository 
+                <a href="#" onclick="toggle_visibility('requirementsDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="requirementsDetails">
                     <span class='nb'>Path to a folder stored in your <a target="_blank" href="https://cernbox.cern.ch/">CERNBox</a>, or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
                 </div>
             </label>
             <br>
-            <select id="requirements_dropdown" name="requirements_type" style="width: auto; height: auto; display: inline-block; border: 1px solid #ccc; background-color: #f7f7f7;">
-                  <option value="git">Git</option>
-                  <option value="cernbox">CERNBox</option>
-            </select>
-            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/repo_env" style="width: 72%; height: auto; display: inline-block;">
+            <div style="display: flex;">
+                <select id="requirements_dropdown" name="requirements_type" onchange="adjustSelectWidth('requirements_dropdown');" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
+                      <option value="git">Git</option>
+                      <option value="cernbox">CERNBox</option>
+                </select>
+                <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/repo_env" style="flex-grow: 1; margin-left: 0; border: 1px solid #afafaf;">
+            </div>
         </div>
         <br>
         
         <div id="customenv_typeSection">
-            <label for="customenv_typeOptions">Custom environment type <a href="#" onclick="toggle_visibility('customenv_typeDetails');"><span class='nbs'>more...</span></a>
+            <label for="customenv_typeOptions">Type <a href="#" onclick="toggle_visibility('customenv_typeDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="customenv_typeDetails">
                     <span class='nb'>Type of custom environment to create. See more in the <a target="_blank" href="https://confluence.cern.ch/display/ACCPY/Getting+started+with+Acc-Py">Acc-Py User guide</a></span>
                 </div>
             </label>
             <select id="customenv_typeOptions" name="customenv_type"></select>
-        </div>
-        <br>
-        <div id="autoenvSection">
-            <input type="checkbox" id="autoenvOption" name="autoenv" checked style="width: auto; height: auto; display: inline-block;">
-            <label for="autoenvOption" style="margin-right: 5%;">Automatically activation <a href="#" onclick="toggle_visibility('autoenvDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="autoenvDetails">
-                    <span class='nb'>Automatically activates the environment when opening the terminal.</span>
-                </div>
-            </label>
         </div>
         <br>
     </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -15,7 +15,7 @@
         var lcgData;
 
         // Data is taken from from lcgFormConfig global variable
-        var lcgFormOptions = lcgFormConfig['options'];
+        var lcgFormOptions = lcgFormConfig['lcg_options'];
         for (key in lcgFormOptions) {
             lcgData = lcgFormOptions[key];
             if (lcgData.type === "selection" && lcgData.lcg.value === lcgValue) {
@@ -84,7 +84,7 @@
             }
 
             // set LCG option in the rendered form - first LCG is default
-            const lcgFormOptions = lcgFormConfig['options'];
+            const lcgFormOptions = lcgFormConfig['lcg_options'];
             selectLCG.innerHTML = '';
             var firstLCGSelected = false;
             for( var i = 0 ; i < lcgFormOptions.length ; i++ ){

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -225,6 +225,7 @@
         var hiddenPlatformOptions = document.getElementById('hiddenPlatformOptions');
 
         var isAlma = platformOptions.selectedOptions[0].text.startsWith('AlmaLinux 9');
+        var isNXCALS = clusterOptions.selectedOptions[0].text.startsWith('BE NXCALS (NXCals)');
 
         if (isAlma) {
             /* On Alma9, make sure cluster selection is enabled and that users can
@@ -232,8 +233,11 @@
             clusterOptions.removeAttribute('disabled');
             jupyterLabOption.removeAttribute('disabled');
         } else {
-            clusterOptions.setAttribute('disabled', '');
-            clusterOptions.selectedIndex = 0;
+            if (!isNXCALS) {
+                clusterOptions.setAttribute('disabled', '');
+                clusterOptions.selectedIndex = 0;
+            }
+
             jupyterLabOption.setAttribute('disabled', '');
         }
 

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -36,6 +36,20 @@
     }
 
     /**
+     * Enable display of element if previously disabled, and disable if previously enabled
+     */
+    function validate_repository_input() {
+        var repoInput = document.getElementById('repositoryOption');
+        const repoPattern = new RegExp(repoInput.pattern);
+
+        if (repoInput.value && !repoPattern.test(repoInput.value)) {
+            repoInput.style.backgroundColor = '#ffcccc';
+        } else {
+            repoInput.style.backgroundColor = '#ffffff';
+        }
+    }
+
+    /**
      * Renders a form based on config file
      */
     function adjust_form() {
@@ -109,15 +123,15 @@
 
         var available_configs = {
             'lcg': [
-                {elementName: 'platformOptions', formKey: "platforms"}, 
-                {elementName: 'coresOptions', formKey: "cores"}, 
-                {elementName: 'memoryOptions', formKey: "memory"}, 
-                {elementName: 'clusterOptions', formKey: "clusters"}, 
-                {elementName: 'condorOptions', formKey: "condor"}
+                {elementName: 'platformOptions', formKey: 'platforms'}, 
+                {elementName: 'coresOptions', formKey: 'cores'}, 
+                {elementName: 'memoryOptions', formKey: 'memory'}, 
+                {elementName: 'clusterOptions', formKey: 'clusters'}, 
+                {elementName: 'condorOptions', formKey: 'condor'}
             ],
             'customenv': [
-                {elementName: 'coresOptions', formKey: "cores"},
-                {elementName: 'memoryOptions', formKey: "memory"}
+                {elementName: 'coresOptions', formKey: 'cores'},
+                {elementName: 'memoryOptions', formKey: 'memory'}
             ]
         };
 
@@ -152,18 +166,22 @@
         tempElement.style.whiteSpace = 'nowrap';
         tempElement.style.fontSize = window.getComputedStyle(selectElement).fontSize;
         tempElement.innerHTML = selectedOptionText;
-        
+
         document.body.appendChild(tempElement);
         const width = tempElement.offsetWidth;
         document.body.removeChild(tempElement);
-        
+
         selectElement.style.width = `${width + 50}px`;
 
         const repositoryOption = document.getElementById('repositoryOption');
         if (selectElement.value === 'eos') {
             repositoryOption.placeholder = 'e.g. $CERNBOX_HOME/MyFolder';
+            // Regular expression pattern for the repository provided by a EOS folder.
+            repositoryOption.pattern = '^(\\\$CERNBOX_HOME(\\/[^<>\|\\\\:()&;,\n]+)*\\/?|\\/eos\\/user\\/[a-z](\\/[^<>\|\\\\:()&;,\n]+)+\\/?)$';
         } else if (selectElement.value === 'git') {
             repositoryOption.placeholder= "e.g. https://gitlab.cern.ch/user/myrepo";
+            // Regular expression pattern for the repository provided by a GitLab or GitHub repository.
+            repositoryOption.pattern = '^https?:\\/\\/(?:github\\.com|gitlab\\.cern\\.ch)\\/([a-zA-Z0-9_-]+)\\/([a-zA-Z0-9_-]+)\\/?$';
         }
     }
 
@@ -307,7 +325,7 @@
                     <option value="eos">EOS</option>
                     <option value="git">Git</option>
                 </select>
-                <input type="text" id="repositoryOption" name="repository" style="flex-grow: 1; margin-left: 0; border: 1px solid #afafaf;">
+                <input type="text" id="repositoryOption" name="repository" style="flex-grow: 1; margin-left: 0; border: 1px solid #afafaf;" oninput="validate_repository_input();">
             </div>
         </div>
         <br>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -6,7 +6,24 @@
 
     var lcgFormConfig = {{ options_form_config }};
 
-    var accpyVersions = ["2020.11", "2021.12", "2023.06"];
+    const customenv_types = [
+      {
+        "value": "python-python3",
+        "text": "Python 3"
+      },
+      {
+        "value": "accpy-2023.06",
+        "text": "Acc-Py 2023.06"
+      },
+      {
+        "value": "accpy-2021.12",
+        "text": "Acc-Py 2021.12"
+      },
+      {
+        "value": "accpy-2020.11",
+        "text": "Acc-Py 2020.11"
+      }
+    ];
 
     var formInitialized = false;
 
@@ -38,7 +55,6 @@
                 break;
             }
         }
-        selector.setAttribute('disabled', '');
     }
 
     /*
@@ -47,11 +63,10 @@
    function selectDefaultLCG(selector) {
         for (var i = 0; i < selector.options.length; i++) {
             if (selector.options[i].value === 'LCG_105_swan') {
-               selector.options[i].selected = true;
-               break;
+                selector.options[i].selected = true;
+                break;
             }
         }
-        selector.setAttribute('disabled', '');
     }
 
     /**
@@ -199,17 +214,22 @@
             selectCondor.add(selectCondorOption);
         }
 
-        // adjust accpy versions option for customenvs
-        var selectAccpy = document.getElementById('accpyOptions');
-        selectAccpy.innerHTML = '';
+        // adjust customenv type options for customenvs
+        var selectCustomenv_type = document.getElementById('customenv_typeOptions');
+        selectCustomenv_type.innerHTML = '';
+        
+        for( var i = 0 ; i < customenv_types.length ; i++ ){
+            var customenv_type = customenv_types[i];
 
-        accpyVersions.forEach(version => {
-            var selectAccpyOption = document.createElement("option");
-            selectAccpyOption.value = version;
-            selectAccpyOption.text = version;
-            selectAccpy.add(selectAccpyOption);
-        });
-        selectAccpy.selectedIndex = 0;
+            var customenv_typeOption = document.createElement("option");
+            customenv_typeOption.value = customenv_type.value;
+            customenv_typeOption.text = customenv_type.text;
+            if (i === 0) {
+                customenv_typeOption.selected = true;
+            }
+
+            selectCustomenv_type.add(customenv_typeOption);
+        }
     }
 
     /**
@@ -218,49 +238,28 @@
     function adjust_customenv() {
         var lcgOption = document.getElementById('lcgOption');
         var customenvOption = document.getElementById('customenvOption');
+        
         var customenv_config = document.getElementById('customenv_config');
         var external_config = document.getElementById('external_config');
-        var lcgSection = document.getElementById('lcgSection');
+        var software_config = document.getElementById('software_config');
         var lcgReleaseOptions = document.getElementById('lcgReleaseOptions');
         var platformOptions = document.getElementById('platformOptions');
         
         if (lcgOption.checked) {
+            software_config.style.display = 'block';
             customenv_config.style.display = 'none';
             external_config.style.display = 'block';
-            lcgSection.style.visibility = 'visible';
-            lcgReleaseOptions.removeAttribute('disabled');
-            lcgReleaseOptions.selectedIndex = 1;
-            platformOptions.selectedIndex = 0;
-            platformOptions.removeAttribute('disabled');
             adjust_form();
             adjust_spark();
-        } else if (customenvOption.checked ) {
+        } else if (customenvOption.checked) {
             selectDefaultLCG(lcgReleaseOptions);
             adjust_form();
             selectAlma9(platformOptions);
+            software_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_config.style.display = 'none';
-            adjust_accpy();
         } 
     }
-
-    /**
-     * Modifies the some elements according to the selected Acc-Py version
-     */
-    function adjust_accpy() {
-        var accpyOption = document.getElementById('accpyOption');
-        var cvmfsOption = document.getElementById('cvmfsOption');
-        var otherOption = document.getElementById('otherOption');
-        
-        var lcgSection = document.getElementById('lcgSection');
-        var accpySection = document.getElementById('accpySection');
-        var pythonSection = document.getElementById('pythonSection');
-
-        lcgSection.style.visibility = !cvmfsOption.checked ? 'hidden' : 'visible';
-        accpySection.style.display = !accpyOption.checked ? 'none' : 'block';
-        pythonSection.style.display = !otherOption.checked ? 'none' : 'block';
-    }
-
 
     /**
      * Modifies the selection of Spark clusters depending on the chosen platform
@@ -294,132 +293,104 @@
     </label>
     <br><br>
 
-    <div>
-        <label>Configuration <a href="#" onclick="toggle_visibility('configDetails');"><span class='nbs'>more...</span></a>
-            <div style="display:none;" id="configDetails">
-                <span class='nb'>Configuration type for your container.</span>
+    <div id="source_typeSection">
+        <h2>Software</h2>
+        <label>Source <a href="#" onclick="toggle_visibility('sourceDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="sourceDetails">
+                <span class='nb'>Source type for your container.</span>
             </div>
         </label>
         <br>
-        <input type="radio" id="lcgOption" name="configType" value="lcg" checked onchange="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
+        <input type="radio" id="lcgOption" name="source_type" value="lcg" checked onchange="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
         <label for="lcgOption" style="margin-right: 5%;">LCG</label>
-        <input type="radio" id="customenvOption" name="configType" value="customenv" onchange="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
+        <input type="radio" id="customenvOption" name="source_type" value="customenv" onchange="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
         <label for="customenvOption">Custom Environment</label>
+        <br>
     </div>
-    <br>
-
-    <div id="lcgSection">
-        <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
-            <div style="display:none;" id="lcgReleaseDetails">
-                <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
-            </div>
-        </label>
-        <select id="lcgReleaseOptions" name="LCG-rel" onchange="adjust_form();">
-        </select>
-    </div>
-    <br>
     
-    <div id="plataformSection">
-        <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
-            <div style="display:none;" id="platformDetails">
-                <span class='nb'>The combination of compiler version and flags.</span>
-            </div>
-        </label>
-        <select id="platformOptions" name="platform" onchange="adjust_spark();"></select>
+    <div id="software_config">
+        <div id="lcgSection">
+            <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="lcgReleaseDetails">
+                    <span class='nb'>Software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
+                </div>
+            </label>
+            <select id="lcgReleaseOptions" name="LCG-rel" onchange="adjust_form();">
+            </select>
+        </div>
+        <br>
+        
+        <div id="plataformSection">
+            <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="platformDetails">
+                    <span class='nb'>Combination of compiler version and flags.</span>
+                </div>
+            </label>
+            <select id="platformOptions" name="platform" onchange="adjust_spark();"></select>
+        </div>
+        <br>
+        
+        <div id="scriptenvSection">
+            <label for="scriptenvOption">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="scriptenvDetails">
+                    <span class='nb'>User-provided bash script to define custom environment variables. The variable CERNBOX_HOME is resolved to the proper /eos/user/u/username directory.</span>
+                </div>
+            </label>
+            <input type="text" id="scriptenvOption" name="scriptenv" placeholder="e.g. $CERNBOX_HOME/MySWAN/myscript.sh">
+        </div>
+        <br>
     </div>
-    <br>
-    
-    <div id="scriptenvSection">
-        <label for="scriptenvOption">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
-            <div style="display:none;" id="scriptenvDetails">
-                <span class='nb'>User-provided bash script to define custom environment variables. The variable CERNBOX_HOME is resolved to the proper /eos/user/u/username directory.</span>
-            </div>
-        </label>
-        <input type="text" id="scriptenvOption" name="scriptenv" placeholder="e.g. $CERNBOX_HOME/MySWAN/myscript.sh">
-    </div>
-    <br>
-    
-    <div id="coresSection">
-        <label for="coresOptions">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
-            <div style="display:none;" id="ncoresDetails">
-                <span class='nb'>Number of cores to associate to the container.</span>
-            </div>
-        </label>
-        <select id="coresOptions" name="ncores"></select>
-    </div>
-    <br>
-
-    <div id="memorySection">
-        <label for="memoryOptions">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
-            <div style="display:none;" id="memoryDetails">
-                <span class='nb'>Amount of Memory allocated to the container.</span>
-            </div>
-        </label>
-        <select id="memoryOptions" name="memory"></select>
-    </div>
-    <br>
 
     <!-- Custom environment configuration -->
     <div id="customenv_config" style="display: none;">
-        <h2 for="computing-resources">Custom environment configuration</h2>
-        
-        <div id="envnameSection">
-            <label for="envnameOption">Environment <a href="#" onclick="toggle_visibility('envnameDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="envnameDetails">
-                    <span class='nb'>Name of the new environment to create.</span>
-                </div>
-            </label>
-            <input type="text" id="envnameOption" name="env_name" placeholder="e.g. env1">
-        </div>
-        <br>
-
         <div id="requirementsSection">
-            <label for="requirementsOption">Requirements <a href="#" onclick="toggle_visibility('requirementsDetails');"><span class='nbs'>more...</span></a>
+            <label for="requirementsOption">Git Repository <a href="#" onclick="toggle_visibility('requirementsDetails');"><span class='nbs'>more...</span></a>
                 <div style="display:none;" id="requirementsDetails">
                     <span class='nb'>Path to a requirements file stored in your <a target="_blank" href="https://cernbox.cern.ch/">CERNBox</a>, or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
                 </div>
             </label>
-            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. SWAN_projects/requirements.txt, https://github.com/user/env1">
+            <input type="text" id="requirementsOption" name="requirements" placeholder="e.g. https://gitlab.cern.ch/user/env1">
+        </div>
+        <br>
+        
+        <div id="customenv_typeSection">
+            <label for="customenv_typeOptions">Custom environment type <a href="#" onclick="toggle_visibility('customenv_typeDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="customenv_typeDetails">
+                    <span class='nb'>Type of custom environment to create. See more in the <a target="_blank" href="https://confluence.cern.ch/display/ACCPY/Getting+started+with+Acc-Py">Acc-Py User guide</a></span>
+                </div>
+            </label>
+            <select id="customenv_typeOptions" name="customenv_type"></select>
+        </div>
+        <br>
+    </div>
+    
+    <div id="resources_config">
+        <h2>Session resources</h2>
+
+        <div id="coresSection">
+            <label for="coresOptions">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="ncoresDetails">
+                    <span class='nb'>Number of cores to associate to the container.</span>
+                </div>
+            </label>
+            <select id="coresOptions" name="ncores"></select>
         </div>
         <br>
 
-        <div id="customenvTypeSection" style="display: block;">
-            <label>Custom environment type <a href="#" onclick="toggle_visibility('customenvDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="customenvDetails">
-                    <span class='nb'>Type of custom environment to create.</span>
+        <div id="memorySection">
+            <label for="memoryOptions">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="memoryDetails">
+                    <span class='nb'>Amount of Memory allocated to the container.</span>
                 </div>
             </label>
-            <br>
-            <input type="radio" id="cvmfsOption" name="customenvType" value="cvmfs" checked onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
-            <label for="cvmfsOption" style="margin-right: 5%;">CVMFS Python</label>
-            <input type="radio" id="accpyOption" name="customenvType" value="accpy" onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
-            <label for="accpyOption" style="margin-right: 5%;">Acc-Py</label>
-            <input type="radio" id="otherOption" name="customenvType" value="custom_python" onchange="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
-            <label for="otherOption" style="margin-right: 5%;">Other</label>
-        </div>
-        <br>
-        <div id="accpySection" style="display: none;">
-            <label for="accpyOptions">Acc-Py version <a href="#" onclick="toggle_visibility('accpyDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="accpyDetails">
-                    <span class='nb'>Version for Acc-Py. See more in the <a target="_blank" href="https://confluence.cern.ch/display/ACCPY/Getting+started+with+Acc-Py">Acc-Py User guide</a></span>
-                </div>
-            </label>
-            <select id="accpyOptions" name="accpy_version"></select>
-        </div>
-        <div id="pythonSection" style="display: none;">
-            <label for="pythonOption">Python path <a href="#" onclick="toggle_visibility('pythonDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="pythonDetails">
-                    <span class='nb'>Path for an alternative Python binary</span>
-                </div>
-            </label>
-            <input type="text" id="pythonOption" name="custom_python" placeholder="e.g. /usr/bin/python3">
+            <select id="memoryOptions" name="memory"></select>
         </div>
         <br>
     </div>
 
     <!-- External computing resources -->
     <div id="external_config" style="display: block;">
-        <h2 for="computing-resources">External computing resources</h2>
+        <h2>External computing resources</h2>
         
         <div id="clusterSection">
             <label for="clusterOptions">Spark cluster <a href="#" onclick="toggle_visibility('clusterDetails');"><span class='nbs'>more...</span></a>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -6,6 +6,8 @@
 
     var lcgFormConfig = {{ options_form_config }};
 
+    var accpyVersions = ["2020.11", "2021.12", "2023.06"];
+
     var formInitialized = false;
 
     /**
@@ -24,6 +26,32 @@
         }
 
         throw "LCG Data not found"
+    }
+
+    /*
+     * Selects AlmaLinux 9 in the LCG plataform options
+     */
+    function selectAlma9(selector) {
+        for (var i = 0; i < selector.options.length; i++) {
+            if (selector.options[i].text.startsWith('AlmaLinux 9')) {
+                selector.options[i].selected = true;
+                break;
+            }
+        }
+        selector.setAttribute('disabled', '');
+    }
+    
+    /*
+    * Selects default LCG release (105)
+    */
+   function selectDefaultLCG(selector) {
+        for (var i = 0; i < selector.options.length; i++) {
+           if (selector.options[i].value === '105') {
+               selector.options[i].selected = true;
+               break;
+            }
+        }
+        selector.setAttribute('disabled', '');
     }
 
     /**
@@ -170,7 +198,64 @@
 
             selectCondor.add(selectCondorOption);
         }
+
+        // adjust accpy versions option for customenvs
+        var selectAccpy = document.getElementById('accpyOptions');
+        selectAccpy.innerHTML = '';
+
+        accpyVersions.forEach(version => {
+            var selectAccpyOption = document.createElement("option");
+            selectAccpyOption.value = version;
+            selectAccpyOption.text = version;
+            selectAccpy.add(selectAccpyOption);
+        });
+        selectAccpy.selectedIndex = 0;
     }
+
+    function adjust_customenv() {
+        adjust_form();
+        var lcgOption = document.getElementById('lcgOption');
+        var customenvOption = document.getElementById('customenvOption');
+        
+        var customenv_config = document.getElementById('customenv_config');
+        var external_config = document.getElementById('external_config');
+        
+        var lcgSection = document.getElementById('lcgSection');
+        var lcgReleaseOptions = document.getElementById('lcgReleaseOptions');
+        var platformOptions = document.getElementById('platformOptions');
+        
+        if (lcgOption.checked) {
+            customenv_config.style.display = 'none';
+            external_config.style.display = 'block';
+            lcgSection.style.visibility = 'visible';
+            lcgReleaseOptions.removeAttribute('disabled');
+            lcgReleaseOptions.selectedIndex = 1;
+            platformOptions.selectedIndex = 0;
+            platformOptions.removeAttribute('disabled');
+            adjust_spark();
+        } else if (customenvOption.checked ) {
+            customenv_config.style.display = 'block';
+            external_config.style.display = 'none';
+            selectDefaultLCG(lcgReleaseOptions);
+            selectAlma9(platformOptions);
+            adjust_accpy();
+        } 
+    }
+
+    function adjust_accpy() {
+        var accpyOption = document.getElementById('accpyOption');
+        var cvmfsOption = document.getElementById('cvmfsOption');
+        var otherOption = document.getElementById('otherOption');
+        
+        var lcgSection = document.getElementById('lcgSection');
+        var accpySection = document.getElementById('accpySection');
+        var pythonSection = document.getElementById('pythonSection');
+
+        lcgSection.style.visibility = !cvmfsOption.checked ? 'hidden' : 'visible';
+        accpySection.style.display = !accpyOption.checked ? 'none' : 'block';
+        pythonSection.style.display = !otherOption.checked ? 'none' : 'block';
+    }
+
 
     /**
      * Modifies the selection of Spark clusters depending on the chosen platform
@@ -182,12 +267,10 @@
         var isAlma = platformOptions.selectedOptions[0].text.startsWith('AlmaLinux 9');
 
         if (isAlma) {
-            // Disable Spark cluster selection, since Spark is still not supported
-            // on Alma9
+            // Disable Spark cluster selection, since Spark is still not supported on Alma9
             clusterOptions.setAttribute('disabled', '');
             clusterOptions.selectedIndex = 0;
-        }
-        else {
+        } else {
             // On CentOS7, make sure cluster selection is enabled
             clusterOptions.removeAttribute('disabled');
         }
@@ -196,6 +279,7 @@
     window.onload = adjust_form;
 //-->
 </script>
+
 <div>
     <label for="placeholder">
     <span class='nb' id="optionsHeader">Specify the configuration parameters for the SWAN container that will be created for you.</span>
@@ -204,54 +288,151 @@
     <span class='news' id="alma9">Select <b>AlmaLinux 9</b> as Platform to try out our new experimental Alma9 image with <b>JupyterLab</b> as default interface! More information <a target="_blank" href="https://swan.docs.cern.ch/alma9/">here</a>.</span>
     </label>
     <br><br>
-    <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="lcgReleaseDetails">
-       <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
+
+    <div>
+        <label>Configuration <a href="#" onclick="toggle_visibility('configDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="configDetails">
+                <span class='nb'>Configuration type for your container.</span>
+            </div>
+        </label>
+        <br>
+        <input type="radio" id="lcgOption" name="configType" value="lcg" checked onclick="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
+        <label for="lcgOption" style="margin-right: 5%;">LCG</label>
+        <input type="radio" id="customenvOption" name="configType" value="customenv" onclick="adjust_customenv();" style="width: auto; height: auto; display: inline-block;">
+        <label for="customenvOption">Custom Environment</label>
     </div>
-    </label>
-    <select id="lcgReleaseOptions" name="LCG-rel" onchange="adjust_form();">
-    </select>
     <br>
-    <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="platformDetails">
-       <span class='nb'>The combination of compiler version and flags.</span>
+
+    <div id="lcgSection">
+        <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="lcgReleaseDetails">
+                <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
+            </div>
+        </label>
+        <select id="lcgReleaseOptions" name="LCG-rel" onchange="adjust_form();">
+        </select>
     </div>
-    </label>
-    <select id="platformOptions" name="platform" onchange="adjust_spark();"></select>
     <br>
-    <label for="scriptenvOption">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="scriptenvDetails">
-       <span class='nb'>User-provided bash script to define custom environment variables. The variable CERNBOX_HOME is resolved to the proper /eos/user/u/username directory.</span>
+    
+    <div id="plataformSection">
+        <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="platformDetails">
+                <span class='nb'>The combination of compiler version and flags.</span>
+            </div>
+        </label>
+        <select id="platformOptions" name="platform" onchange="adjust_spark();"></select>
     </div>
-    </label>
-    <input type="text" id="scriptenvOption" name="scriptenv" placeholder="e.g. $CERNBOX_HOME/MySWAN/myscript.sh">
     <br>
-    <label for="coresOptions">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="ncoresDetails">
-       <span class='nb'>Number of cores to associate to the container.</span>
+    
+    <div id="scriptenvSection">
+        <label for="scriptenvOption">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="scriptenvDetails">
+                <span class='nb'>User-provided bash script to define custom environment variables. The variable CERNBOX_HOME is resolved to the proper /eos/user/u/username directory.</span>
+            </div>
+        </label>
+        <input type="text" id="scriptenvOption" name="scriptenv" placeholder="e.g. $CERNBOX_HOME/MySWAN/myscript.sh">
     </div>
-    </label>
-    <select id="coresOptions" name="ncores"></select>
     <br>
-    <label for="memoryOptions">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="memoryDetails">
-       <span class='nb'>Amount of Memory allocated to the container.</span>
+    
+    <div id="coresSection">
+        <label for="coresOptions">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="ncoresDetails">
+                <span class='nb'>Number of cores to associate to the container.</span>
+            </div>
+        </label>
+        <select id="coresOptions" name="ncores"></select>
     </div>
-    </label>
-    <select id="memoryOptions" name="memory"></select>
     <br>
-    <h2 for="computing-resources">External computing resources</h2>
-    <label for="clusterOptions">Spark cluster <a href="#" onclick="toggle_visibility('sparkClusterDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="sparkClusterDetails">
-        <span class='nb'>Name of the Spark cluster to connect to from notebooks. See the <a target="_blank" href="https://hadoop-user-guide.web.cern.ch/">Hadoop User guide</a> and the <a target="_blank" href="https://sparktraining.web.cern.ch/">Spark training course</a></span>
+
+    <div id="memorySection">
+        <label for="memoryOptions">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="memoryDetails">
+                <span class='nb'>Amount of Memory allocated to the container.</span>
+            </div>
+        </label>
+        <select id="memoryOptions" name="memory"></select>
     </div>
-    </label>
-    <select id="clusterOptions" name="spark-cluster"></select>
     <br>
-    <label for="condorOptions">HTCondor pool <a href="#" onclick="toggle_visibility('condorDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="condorDetails">
-        <span class='nb'>Name of the HTCondor pool to use.</span>
+
+    <!-- Custom environment configuration -->
+    <div id="customenv_config" style="display: none;">
+        <h2 for="computing-resources">Custom environment configuration</h2>
+        
+        <div id="envnameSection">
+            <label for="envnameOption">Environment <a href="#" onclick="toggle_visibility('envnameDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="envnameDetails">
+                    <span class='nb'>Name of the new environment to create.</span>
+                </div>
+            </label>
+            <input type="text" id="envnameOption" name="env_name" placeholder="e.g. env1">
+        </div>
+        <br>
+
+        <div id="requirementsSection">
+            <label for="requirementsOption">Requirements <a href="#" onclick="toggle_visibility('requirementsDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="requirementsDetails">
+                    <span class='nb'>Path to a requirements file stored in your <a target="_blank" href="https://cernbox.cern.ch/">CERNBox</a>, or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
+                </div>
+            </label>
+            <input type="text" id="requirementsOption" name="req" placeholder="e.g. SWAN_projects/requirements.txt, https://github.com/user/env1">
+        </div>
+        <br>
+
+        <div id="customenvTypeSection" style="display: block;">
+            <label>Custom environment type <a href="#" onclick="toggle_visibility('customenvDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="customenvDetails">
+                    <span class='nb'>Type of custom environment to create.</span>
+                </div>
+            </label>
+            <br>
+            <input type="radio" id="cvmfsOption" name="customenvType" value="cvmfs" checked onclick="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
+            <label for="cvmfsOption" style="margin-right: 5%;">CVMFS Python</label>
+            <input type="radio" id="accpyOption" name="customenvType" value="accpy" onclick="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
+            <label for="accpyOption" style="margin-right: 5%;">Acc-Py</label>
+            <input type="radio" id="otherOption" name="customenvType" value="custom_python" onclick="adjust_accpy();" style="width: auto; height: auto; display: inline-block;">
+            <label for="otherOption" style="margin-right: 5%;">Other</label>
+        </div>
+        <br>
+        <div id="accpySection" style="display: none;">
+            <label for="accpyOptions">Acc-Py Version <a href="#" onclick="toggle_visibility('accpyDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="accpyDetails">
+                    <span class='nb'>Version for Acc-Py. See more in the <a target="_blank" href="https://confluence.cern.ch/display/ACCPY/Getting+started+with+Acc-Py">Acc-Py User guide</a></span>
+                </div>
+            </label>
+            <select id="accpyOptions" name="accpy_version"></select>
+        </div>
+        <div id="pythonSection" style="display: none;">
+            <label for="pythonOption">Python path <a href="#" onclick="toggle_visibility('pythonDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="pythonDetails">
+                    <span class='nb'>Path for an alternative Python binary</span>
+                </div>
+            </label>
+            <input type="text" id="pythonOption" name="accpy_version" placeholder="e.g. /usr/bin/python3">
+        </div>
+        <br>
     </div>
-    </label>
-    <select id="condorOptions" name="condor-pool"></select>
+
+    <!-- External computing resources -->
+    <div id="external_config" style="display: block;">
+        <h2 for="computing-resources">External computing resources</h2>
+        
+        <div id="clusterSection">
+            <label for="clusterOptions">Spark cluster <a href="#" onclick="toggle_visibility('clusterDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="clusterDetails">
+                    <span class='nb'>Name of the Spark cluster to connect to from notebooks. See the <a target="_blank" href="https://hadoop-user-guide.web.cern.ch/">Hadoop User guide</a> and the <a target="_blank" href="https://sparktraining.web.cern.ch/">Spark training course</a></span>
+                </div>
+            </label>
+            <select id="clusterOptions" name="spark-cluster"></select>
+        </div>
+        <br>
+
+        <div id="condorSection">
+            <label for="condorOptions">HTCondor pool <a href="#" onclick="toggle_visibility('condorDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="condorDetails">
+                    <span class='nb'>Name of the HTCondor pool to use.</span>
+                </div>
+            </label>
+            <select id="condorOptions" name="condor-pool"></select>
+        </div>
+    </div>
 </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -6,25 +6,6 @@
 
     var lcgFormConfig = {{ options_form_config }};
 
-    const customenv_types = [
-      {
-        "value": "python-python3",
-        "text": "Generic"
-      },
-      {
-        "value": "accpy-2023.06",
-        "text": "Acc-Py 2023.06"
-      },
-      {
-        "value": "accpy-2021.12",
-        "text": "Acc-Py 2021.12"
-      },
-      {
-        "value": "accpy-2020.11",
-        "text": "Acc-Py 2020.11"
-      }
-    ];
-
     var formInitialized = false;
 
     /**
@@ -103,7 +84,7 @@
             }
 
             // set LCG option in the rendered form - first LCG is default
-            var lcgFormOptions = lcgFormConfig['options'];
+            const lcgFormOptions = lcgFormConfig['options'];
             selectLCG.innerHTML = '';
             var firstLCGSelected = false;
             for( var i = 0 ; i < lcgFormOptions.length ; i++ ){
@@ -125,6 +106,33 @@
                 }
 
                 selectLCG.add(selectLCGOption);
+            }
+        
+            // set customenv type options for customenvs
+            const customenvTypes = lcgFormConfig['customenv_options'];
+            var selectCustomenv_type = document.getElementById('customenv_typeOptions');
+            selectCustomenv_type.innerHTML = '';
+            var firstCustomenvTypeSelected = false;
+
+            for( var i = 0 ; i < customenvTypes.length ; i++ ){
+                var customenv_type = customenvTypes[i];
+
+                var customenv_typeOption = document.createElement("option");
+                if (customenv_type.type === "label") {
+                    customenv_typeOption.disabled="disabled";
+                    customenv_typeOption.style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0";
+                    customenv_typeOption.value=customenv_type.label.value;
+                    customenv_typeOption.text=customenv_type.label.text;
+                } else {
+                    if (!firstCustomenvTypeSelected) {
+                        firstCustomenvTypeSelected = true;
+                        customenv_typeOption.selected = true;
+                    }
+                    customenv_typeOption.value=customenv_type.builder.value;
+                    customenv_typeOption.text=customenv_type.builder.text;
+                }
+
+                selectCustomenv_type.add(customenv_typeOption);
             }
         }
 
@@ -219,22 +227,6 @@
             selectCondor.add(selectCondorOption);
         }
 
-        // adjust customenv type options for customenvs
-        var selectCustomenv_type = document.getElementById('customenv_typeOptions');
-        selectCustomenv_type.innerHTML = '';
-        
-        for( var i = 0 ; i < customenv_types.length ; i++ ){
-            var customenv_type = customenv_types[i];
-
-            var customenv_typeOption = document.createElement("option");
-            customenv_typeOption.value = customenv_type.value;
-            customenv_typeOption.text = customenv_type.text;
-            if (i === 0) {
-                customenv_typeOption.selected = true;
-            }
-
-            selectCustomenv_type.add(customenv_typeOption);
-        }
     }
 
     /**

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -39,7 +39,7 @@
      * Renders a form based on config file
      */
     function adjust_form() {
-        const sourceOptions = document.getElementsByName('source_type');
+        const sourceOptions = document.getElementsByName('software_source');
         let selectedSource = null;
         for (let i = 0; i < sourceOptions.length; i++) {
             if (sourceOptions[i].checked) {
@@ -243,7 +243,7 @@
     <br><br>
 
     <!-- Source Type selection -->
-    <div id="source_typeSection">
+    <div id="software_sourceSection">
         <h2>Software</h2>
         <label>Source <a href="#" onclick="toggle_visibility('sourceDetails');"><span class='nbs'>more...</span></a>
             <div style="display:none;" id="sourceDetails">
@@ -251,9 +251,9 @@
             </div>
         </label>
         <br>
-        <input type="radio" id="lcgOption" name="source_type" value="lcg" checked onchange="toggle_form();" style="width: auto; height: auto; display: inline-block;">
+        <input type="radio" id="lcgOption" name="software_source" value="lcg" checked onchange="toggle_form();" style="width: auto; height: auto; display: inline-block;">
         <label for="lcgOption" style="margin-right: 5%;">LCG</label>
-        <input type="radio" id="customenvOption" name="source_type" value="customenv" onchange="toggle_form();" style="width: auto; height: auto; display: inline-block;">
+        <input type="radio" id="customenvOption" name="software_source" value="customenv" onchange="toggle_form();" style="width: auto; height: auto; display: inline-block;">
         <label for="customenvOption">Custom Environment</label>
         <br><br>
     </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -6,6 +6,8 @@
 
     var formConfig = {{ options_form_config }};
 
+    var accpyVersions = ["2020.11", "2021.12", "2023.06"];
+
     var formInitialized = false;
 
     /**
@@ -22,6 +24,32 @@
         }
 
         throw `${formElement} Data not found`
+    }
+
+    /*
+     * Selects AlmaLinux 9 in the LCG plataform options
+     */
+    function selectAlma9(selector) {
+        for (var i = 0; i < selector.options.length; i++) {
+            if (selector.options[i].text.startsWith('AlmaLinux 9')) {
+                selector.options[i].selected = true;
+                break;
+            }
+        }
+        selector.setAttribute('disabled', '');
+    }
+    
+    /*
+    * Selects default LCG release (105)
+    */
+   function selectDefaultLCG(selector) {
+        for (var i = 0; i < selector.options.length; i++) {
+           if (selector.options[i].value === '105') {
+               selector.options[i].selected = true;
+               break;
+            }
+        }
+        selector.setAttribute('disabled', '');
     }
 
     /**
@@ -209,6 +237,51 @@
         } 
     }
 
+    function adjust_customenv() {
+        adjust_form();
+        var lcgOption = document.getElementById('lcgOption');
+        var customenvOption = document.getElementById('customenvOption');
+        
+        var customenv_config = document.getElementById('customenv_config');
+        var external_config = document.getElementById('external_config');
+        
+        var lcgSection = document.getElementById('lcgSection');
+        var lcgReleaseOptions = document.getElementById('lcgReleaseOptions');
+        var platformOptions = document.getElementById('platformOptions');
+        
+        if (lcgOption.checked) {
+            customenv_config.style.display = 'none';
+            external_config.style.display = 'block';
+            lcgSection.style.visibility = 'visible';
+            lcgReleaseOptions.removeAttribute('disabled');
+            lcgReleaseOptions.selectedIndex = 1;
+            platformOptions.selectedIndex = 0;
+            platformOptions.removeAttribute('disabled');
+            adjust_spark();
+        } else if (customenvOption.checked ) {
+            customenv_config.style.display = 'block';
+            external_config.style.display = 'none';
+            selectDefaultLCG(lcgReleaseOptions);
+            selectAlma9(platformOptions);
+            adjust_accpy();
+        } 
+    }
+
+    function adjust_accpy() {
+        var accpyOption = document.getElementById('accpyOption');
+        var cvmfsOption = document.getElementById('cvmfsOption');
+        var otherOption = document.getElementById('otherOption');
+        
+        var lcgSection = document.getElementById('lcgSection');
+        var accpySection = document.getElementById('accpySection');
+        var pythonSection = document.getElementById('pythonSection');
+
+        lcgSection.style.visibility = !cvmfsOption.checked ? 'hidden' : 'visible';
+        accpySection.style.display = !accpyOption.checked ? 'none' : 'block';
+        pythonSection.style.display = !otherOption.checked ? 'none' : 'block';
+    }
+
+
     /**
      * Modifies the selection of Spark clusters and enables users to choose
      * to use the JupyterLab interface depending on the chosen platform
@@ -370,9 +443,14 @@
     <select id="platformOptions" onchange="adjust_options();"></select>
     <input type="hidden" id="hiddenPlatformOptions" name="platform">
     <br>
-    <label for="scriptenvOption">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="scriptenvDetails">
-       <span class='nb'>User-provided bash script to define custom environment variables. The variable CERNBOX_HOME is resolved to the proper /eos/user/u/username directory.</span>
+    
+    <div id="plataformSection">
+        <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="platformDetails">
+                <span class='nb'>The combination of compiler version and flags.</span>
+            </div>
+        </label>
+        <select id="platformOptions" name="platform" onchange="adjust_spark();"></select>
     </div>
     
     <!-- Resources configuration -->

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -48,8 +48,8 @@
     /*
      * Selects AlmaLinux 9 in the LCG plataform options
      */
-    function selectAlma9(id) {
-        var selector = document.getElementById(id);
+    function selectAlma9() {
+        var selector = document.getElementById('platformOptions');
         for (var i = 0; i < selector.options.length; i++) {
             if (selector.options[i].text.startsWith('AlmaLinux 9')) {
                 selector.options[i].selected = true;
@@ -59,12 +59,15 @@
     }
 
     /*
-    * Selects default LCG release (105)
+    * Selects default LCG release (first of recommended section)
     */
-   function selectDefaultLCG(id) {
-        var selector = document.getElementById(id);
+   function selectDefaultLCG() {
+        var selector = document.getElementById('lcgReleaseOptions');
+        var recommend_label = false;
         for (var i = 0; i < selector.options.length; i++) {
-            if (selector.options[i].value === 'LCG_105_swan') {
+            if (selector.options[i].text.includes("Recommended"))
+                recommend_label = true;
+            if (recommend_label === true && !selector.options[i].disabled) {
                 selector.options[i].selected = true;
                 break;
             }
@@ -235,10 +238,10 @@
     }
 
     /**
-     * Allows to adjust the width of the dropdown element based on the selected option
+     * Adjusts the width of the repository type dropdown element based on the selected option
      */
-    function adjustDropdownWidth() {
-        const selectElement = document.getElementById('requirements_dropdown');
+    function adjustRepositoryDropdown() {
+        const selectElement = document.getElementById('repository_type_dropdown');
         const selectedOptionText = selectElement.options[selectElement.selectedIndex].text;
         const tempElement = document.createElement('span');
         tempElement.style.visibility = 'hidden';
@@ -252,18 +255,18 @@
         
         selectElement.style.width = `${width + 50}px`;
 
-        const requirementsOption = document.getElementById('requirementsOption');
+        const repositoryOption = document.getElementById('repositoryOption');
         if (selectElement.value === 'eos') {
-            requirementsOption.placeholder = 'e.g. $CERNBOX_HOME/MySWAN';
+            repositoryOption.placeholder = 'e.g. $CERNBOX_HOME/MyFolder';
         } else if (selectElement.value === 'git') {
-            requirementsOption.placeholder= "e.g. https://gitlab.cern.ch/user/myrepo";
+            repositoryOption.placeholder= "e.g. https://gitlab.cern.ch/user/myrepo";
         }
     }
 
     /**
-     * Modifies the some elements according to the selected type of configuration (LCG or Custom Environments)
+     * Modifies the displayed form according to the selected type of configuration (LCG or Custom Environments)
      */
-    function toggle_forms() {
+    function toggle_form() {
         var lcgOption = document.getElementById('lcgOption');
         var customenvOption = document.getElementById('customenvOption');
         
@@ -277,11 +280,11 @@
             external_config.style.display = 'block';
             adjust_form();
             adjust_spark();
-        } else if (customenvOption.checked) {
-            selectDefaultLCG('lcgReleaseOptions');
+        } else { // if customenvOption.checked
+            selectDefaultLCG();
             adjust_form();
-            selectAlma9('platformOptions');
-            adjustDropdownWidth();
+            selectAlma9();
+            adjustRepositoryDropdown();
             software_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_config.style.display = 'none';
@@ -307,7 +310,7 @@
         }
     }
 
-    window.onload = toggle_forms;
+    window.onload = toggle_form;
 //-->
 </script>
 
@@ -328,9 +331,9 @@
             </div>
         </label>
         <br>
-        <input type="radio" id="lcgOption" name="source_type" value="lcg" checked onchange="toggle_forms();" style="width: auto; height: auto; display: inline-block;">
+        <input type="radio" id="lcgOption" name="source_type" value="lcg" checked onchange="toggle_form();" style="width: auto; height: auto; display: inline-block;">
         <label for="lcgOption" style="margin-right: 5%;">LCG</label>
-        <input type="radio" id="customenvOption" name="source_type" value="customenv" onchange="toggle_forms();" style="width: auto; height: auto; display: inline-block;">
+        <input type="radio" id="customenvOption" name="source_type" value="customenv" onchange="toggle_form();" style="width: auto; height: auto; display: inline-block;">
         <label for="customenvOption">Custom Environment</label>
         <br><br>
     </div>
@@ -370,20 +373,20 @@
 
     <!-- Custom environment configuration -->
     <div id="customenv_config" style="display: none;">
-        <div id="requirementsSection">
-            <label for="requirementsOption">Repository 
-                <a href="#" onclick="toggle_visibility('requirementsDetails');"><span class='nbs'>more...</span></a>
-                <div style="display:none;" id="requirementsDetails">
+        <div id="repositorySection">
+            <label for="repositoryOption">Repository 
+                <a href="#" onclick="toggle_visibility('repositoryDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="repositoryDetails">
                     <span class='nb'>Path to a folder stored in your <a target="_blank" href="https://cernbox.cern.ch/">EOS</a> (/eos/user/u/username), or a <a target="_blank" href="https://github.com/new/">GitHub</a>/<a target="_blank" href="https://gitlab.cern.ch/projects/new">CERN GitLab</a> repository containing a requirements.txt in its root path.</span>
                 </div>
             </label>
             <br>
             <div style="display: flex;">
-                <select id="requirements_dropdown" name="requirements_type" onchange="adjustDropdownWidth();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
+                <select id="repository_type_dropdown" name="repository_type" onchange="adjustRepositoryDropdown();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
                       <option value="git">Git</option>
                       <option value="eos">EOS</option>
                 </select>
-                <input type="text" id="requirementsOption" name="requirements" style="flex-grow: 1; margin-left: 0; border: 1px solid #afafaf;">
+                <input type="text" id="repositoryOption" name="repository" style="flex-grow: 1; margin-left: 0; border: 1px solid #afafaf;">
             </div>
         </div>
         <br>


### PR DESCRIPTION
Result:
Spawner can now launch custom environments through its web interface.

Developments:
Thanks to changes on SwanSpawner and SwanHub, its now possible to avoid having to install all LCG packages and provide a specific amount of packages through cernbox/eos path or git repo containing a requirements.txt file.

This new custom virtual environment can then be launched by a generic python venv or a acc-py stack.

The user gets redirected to /customenv where the process details are shown up in real time, so the users is able to keep up with its going on under the hood. In the end, a completely empty custom environment (just with the provided packages) gets ready for the user to work on.

