### PR TITLE
SwanSpawner: Restrict spark clusters to different platforms

### DIFF
--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -144,6 +144,10 @@
         for( var i = 0 ; i < lcgData.clusters.length ; i++ ){
             var lcgCluster = lcgData.clusters[i];
 
+            if (lcgCluster.value === "k8s" && lcgCluster.value === "hadoop-qa") {
+                continue;
+            }
+
             var selectClusterOption = document.createElement("option");
             selectClusterOption.value = lcgCluster.value;
             selectClusterOption.text = lcgCluster.text;
@@ -177,19 +181,36 @@
      */
     function adjust_spark() {
         var platformOptions = document.getElementById('platformOptions');
-        var clusterOptions  = document.getElementById('clusterOptions');
+
+        function removeCluster(cluster) {
+            var clusterOptions  = document.getElementById('clusterOptions');
+            for (var i = 0; i < clusterOptions.options.length; i++) {
+                if (clusterOptions.options[i].value === cluster) {
+                    clusterOptions.remove(i);
+                    break;
+                }
+            }
+        }
+
+        function addCluster(clusterValue, clusterName) {
+            var selectClusterOption = document.createElement("option");
+            selectClusterOption.value = clusterValue;
+            selectClusterOption.text = clusterName;
+            clusterOptions.add(selectClusterOption);
+        }
 
         var isAlma = platformOptions.selectedOptions[0].text.startsWith('AlmaLinux 9');
 
         if (isAlma) {
-            // Disable Spark cluster selection, since Spark is still not supported
-            // on Alma9
-            clusterOptions.setAttribute('disabled', '');
             clusterOptions.selectedIndex = 0;
+            removeCluster("analytix")
+            addCluster("k8s", "Cloud Containers (K8s)")
+            addCluster("hadoop-qa", "QA")
         }
         else {
-            // On CentOS7, make sure cluster selection is enabled
-            clusterOptions.removeAttribute('disabled');
+            addCluster("analytix", "General Purpose (Analytix)")
+            removeCluster("k8s")
+            removeCluster("hadoop-qa")
         }
     }
 


### PR DESCRIPTION
This is a temporary change to restrict certain spark clusters to users, based on the platform chosen by the user, while the migration to alma9 is not completed.

The analytix cluster will only be available for the CentOS7 platform and the K8s and QA clusters will only be available for the AlmaLinux9.

It will be reverted once the analytix cluster is fully migrated to alma9 thus completing the migration of all spark clusters to that distribution.