### PR TITLE
SwanSpawner: Add form field to prepend python local packages path

### DIFF
--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -29,6 +29,8 @@ def define_SwanSpawner_from(base_class):
 
         lcg_rel_field = 'LCG-rel'
 
+        use_local_packages_field = 'use-local-packages'
+
         platform_field = 'platform'
 
         user_script_env_field = 'scriptenv'
@@ -81,14 +83,15 @@ def define_SwanSpawner_from(base_class):
 
         def options_from_form(self, formdata):
             options = {}
-            options[self.lcg_rel_field]         = formdata[self.lcg_rel_field][0]
-            options[self.platform_field]        = formdata[self.platform_field][0]
-            options[self.user_script_env_field] = formdata[self.user_script_env_field][0]
-            options[self.spark_cluster_field]   = formdata[self.spark_cluster_field][0] if self.spark_cluster_field in formdata.keys() else 'none'
-            options[self.condor_pool]           = formdata[self.condor_pool][0]
-            options[self.user_n_cores]          = int(formdata[self.user_n_cores][0])
-            options[self.user_memory]           = formdata[self.user_memory][0] + 'G'
-            options[self.use_jupyterlab_field]  = formdata.get(self.use_jupyterlab_field, 'unchecked')[0]
+            options[self.lcg_rel_field]             = formdata[self.lcg_rel_field][0]
+            options[self.platform_field]            = formdata[self.platform_field][0]
+            options[self.user_script_env_field]     = formdata[self.user_script_env_field][0]
+            options[self.spark_cluster_field]       = formdata[self.spark_cluster_field][0] if self.spark_cluster_field in formdata.keys() else 'none'
+            options[self.condor_pool]               = formdata[self.condor_pool][0]
+            options[self.user_n_cores]              = int(formdata[self.user_n_cores][0])
+            options[self.user_memory]               = formdata[self.user_memory][0] + 'G'
+            options[self.use_jupyterlab_field]      = formdata.get(self.use_jupyterlab_field, 'unchecked')[0]
+            options[self.use_local_packages_field]  = formdata.get(self.use_local_packages_field, 'unchecked')[0]
 
             self.offload = options[self.spark_cluster_field] != 'none'
 
@@ -139,6 +142,12 @@ def define_SwanSpawner_from(base_class):
             if self.user_options[self.use_jupyterlab_field] == 'checked':
                 env.update(dict(
                     SWAN_USE_JUPYTERLAB = 'true'
+                ))
+
+            # Append path of user packages installed on CERNBox to PYTHONPATH
+            if self.user_options[self.use_local_packages_field] == 'checked':
+                env.update(dict(
+                    SWAN_USE_LOCAL_PACKAGES = 'true'
                 ))
 
             # Enable configuration for CERN HTCondor pool

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -182,6 +182,7 @@
         var platformOptions = document.getElementById('platformOptions');
         var clusterOptions  = document.getElementById('clusterOptions');
         var jupyterLabOption = document.getElementById("use-jupyterlab");
+        var useLocalPackagesOption = document.getElementById('use-local-packages');
 
         /**
          * Store the chosen platform in a hidden form field, as disabled fields
@@ -197,6 +198,7 @@
             select the JupyterLab interface */
             clusterOptions.removeAttribute('disabled');
             jupyterLabOption.removeAttribute('disabled');
+            useLocalPackagesOption.removeAttribute('disabled');
         } else {
             if (!isNXCALS) {
                 clusterOptions.setAttribute('disabled', '');
@@ -204,6 +206,7 @@
             }
 
             jupyterLabOption.setAttribute('disabled', '');
+            useLocalPackagesOption.setAttribute('disabled', '');
         }
 
         hiddenPlatformOptions.value = platformOptions.value;
@@ -212,8 +215,9 @@
     function adjust_platforms() {
         var platformOptions = document.getElementById('platformOptions');
         var jupyterLabOption = document.getElementById('use-jupyterlab');
+        var useLocalPackagesOption = document.getElementById('use-local-packages');
 
-        if (jupyterLabOption.checked) {
+        if (jupyterLabOption.checked || useLocalPackagesOption.checked) {
             platformOptions.setAttribute('disabled', '');
         } else {
             platformOptions.removeAttribute('disabled');
@@ -249,11 +253,24 @@
     <br>
     <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
     <div style="display:none;" id="lcgReleaseDetails">
-       <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
+        <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
+        <br>
+        <span class='nb'>Additionally, it is possible to use Python packages installed by the user on CERNBox. More information <a target="_blank" href="https://swan.docs.cern.ch/advanced/install_packages/">here</a>.</span>
     </div>
     </label>
     <select id="lcgReleaseOptions" name="LCG-rel" onchange="adjust_form();">
     </select>
+    <div style="display: flex; align-items: center">
+        <input
+          id="use-local-packages"
+          type="checkbox"
+          name="use-local-packages"
+          value="checked"
+          style="display: inline; width: initial; margin: 0 8px 0 0"
+          onchange="adjust_platforms();"
+        />
+        <span> Use Python packages installed on CERNBox</span>
+      </div>
     <br>
     <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
     <div style="display:none;" id="platformDetails">


### PR DESCRIPTION
Allow users to choose whether they want their local python packages path prepended to the PYTHONPATH variable, so that they are able to use the packages installed on their CERNBox in SWAN notebooks automatically.

![image](https://github.com/swan-cern/jupyterhub-extensions/assets/53193337/3966b088-1b39-4371-9ecc-409879c85a31)
