### PR TITLE
SwanSpawner: Add metric to monitor the usage of each interface

### DIFF
--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -144,6 +144,17 @@ def define_SwanSpawner_from(base_class):
                     SWAN_USE_JUPYTERLAB = 'true'
                 ))
 
+                user_interface = 'lab'
+            else:
+                user_interface = 'classic'
+
+            self.log_metric(
+                self.user.name,
+                self.this_host,
+                'ui',
+                user_interface
+            )
+
             # Append path of user packages installed on CERNBox to PYTHONPATH
             if self.user_options[self.use_local_packages_field] == 'checked':
                 env.update(dict(


### PR DESCRIPTION
Add log metric to check the number of users that start a session with the classic and jupyterlab interfaces.