### PR TITLE
Revert "SwanSpawner: Add metric to monitor the usage of each interface"

### DIFF
--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -144,17 +144,6 @@ def define_SwanSpawner_from(base_class):
                     SWAN_USE_JUPYTERLAB = 'true'
                 ))
 
-                user_interface = 'lab'
-            else:
-                user_interface = 'classic'
-
-            self.log_metric(
-                self.user.name,
-                self.this_host,
-                'ui',
-                user_interface
-            )
-
             # Append path of user packages installed on CERNBox to PYTHONPATH
             if self.user_options[self.use_local_packages_field] == 'checked':
                 env.update(dict(


### PR DESCRIPTION
This reverts commit f62d99e6418e243c87bf5fd73b081e13050d5081. It is not needed, since a metric is automatically created for any form field when a user setups their session.