### PR TITLE
New feature for custom environments

### DIFF
--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -15,11 +15,25 @@ class SpawnHandlersConfigs(SingletonConfigurable):
         Singleton class where all the configurations are stored
     """
 
+    software_source = 'software_source'
+
+    builder = 'builder'
+
+    builder_version = 'builder_version'
+
+    repo_type = 'repo_type'
+
+    repository = 'repository'
+
     lcg_rel_field = 'LCG-rel'
 
     spark_cluster_field = 'spark-cluster'
 
     user_script_env_field = 'scriptenv'
+
+    customenv_special_type = 'customenv'
+
+    accpy_special_type = 'accpy'
 
     local_home = Bool(
         default_value=False,

--- a/SwanSpawner/swanspawner/swandockerspawner.py
+++ b/SwanSpawner/swanspawner/swandockerspawner.py
@@ -12,7 +12,6 @@ from traitlets import (
     Unicode,
     Bool,
     Int,
-    Dict
 )
 
 from socket import (
@@ -97,12 +96,6 @@ class SwanDockerSpawner(define_SwanSpawner_from(SystemUserSpawner)):
             self.extra_host_config['port_bindings'] = {}
             self.extra_create_kwargs['ports'] = []
 
-            if self.lcg_rel_field not in self.user_options:
-                # session spawned via the API, in binder start notebook with jovyan user
-                self.extra_create_kwargs['working_dir'] = "/home/jovyan"
-                self.extra_create_kwargs['user'] = 'jovyan'
-                self.extra_create_kwargs['command'] = ["jupyterhub-singleuser","--ip=0.0.0.0","--NotebookApp.default_url=/lab"]
-
             # Avoid overriding the default container output port, defined by the Spawner
             if not self.use_internal_ip:
                 self.extra_host_config['port_bindings'][self.port] = (self.host_ip,)
@@ -146,17 +139,17 @@ class SwanDockerSpawner(define_SwanSpawner_from(SystemUserSpawner)):
         """Perform the operations necessary for mounting
         EOS, GPU support, authenticating HDFS and authenticating spark clusters.
         """
-        
+
         # default values when spawned via API (e.g binder)
         with open(self.options_form_config) as json_file:
             options_form_config_data = json.load(json_file)
 
         username = self.user.name
-        platform = self.user_options.get(self.platform_field,options_form_config_data["options"][1]['platforms'][0]['value'])
-        lcg_rel = self.user_options.get(self.lcg_rel_field,options_form_config_data["options"][1]["lcg"]["value"])
-        cluster = self.user_options.get(self.spark_cluster_field,options_form_config_data["options"][1]['clusters'][0]['value'])
-        cpu_quota = self.user_options.get(self.user_n_cores,int(options_form_config_data["options"][1]['cores'][0]['value']))
-        mem_limit = self.user_options.get(self.user_memory,options_form_config_data["options"][1]['memory'][0]['value'] + 'G')
+        platform = self.user_options.get(self.platform_field, options_form_config_data['lcg_options'][1]['platforms'][1]['value']) # Default: Alma9 (x86_64-el9-gcc13-opt)
+        lcg_rel = self.user_options.get(self.lcg_rel_field, options_form_config_data['lcg_options'][1]['lcg']['value']) # Default: LCG_105a_swan
+        cluster = self.user_options.get(self.spark_cluster_field, options_form_config_data['lcg_options'][1]['clusters'][0]['value']) # Default: none
+        cpu_quota = self.user_options.get(self.user_n_cores, int(options_form_config_data['lcg_options'][1]['cores'][0]['value'])) # Default: 2
+        mem_limit = self.user_options.get(self.user_memory, options_form_config_data['lcg_options'][1]['memory'][0]['value'] + 'G') # Default: 8G
 
         try:
             start_time_configure_user = time.time()

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -112,8 +112,8 @@ def define_SwanSpawner_from(base_class):
                 options[self.repository]      = formdata[self.repository][0]
                 options[self.repo_type]       = formdata[self.repo_type][0]
 
-                if not options[self.repository]:
-                    raise ValueError("No Repository specified")
+                if options[self.repository] is None or options[self.repository].strip() == '':
+                    raise ValueError('No Repository specified')
             else:
                 options[self.lcg_rel_field]         = formdata[self.lcg_rel_field][0]
                 options[self.platform_field]        = formdata[self.platform_field][0]

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -10,7 +10,6 @@ from socket import gethostname
 from traitlets import (
     Unicode,
     Bool,
-    Dict,
     Int
 )
 
@@ -26,6 +25,16 @@ def define_SwanSpawner_from(base_class):
     """
 
     class SwanSpawner(base_class):
+
+        software_source = 'software_source'
+
+        builder = 'builder'
+
+        builder_version = 'builder_version'
+
+        repo_type = 'repo_type'
+
+        repository = 'repository'
 
         lcg_rel_field = 'LCG-rel'
 
@@ -44,6 +53,12 @@ def define_SwanSpawner_from(base_class):
         spark_cluster_field = 'spark-cluster'
 
         condor_pool = 'condor-pool'
+
+        customenv_special_type = 'customenv'
+
+        lcg_special_type = 'lcg'
+
+        eos_special_type = 'eos'
 
         options_form_config = Unicode(
             config=True,
@@ -82,18 +97,31 @@ def define_SwanSpawner_from(base_class):
                 self.options_form = self._render_templated_options_form
 
         def options_from_form(self, formdata):
+            # Builders are specified in builder-builderversion format
+            builder, builder_version = formdata[self.builder][0].lower().split('-')
+
             options = {}
-            options[self.lcg_rel_field]             = formdata[self.lcg_rel_field][0]
-            options[self.platform_field]            = formdata[self.platform_field][0]
-            options[self.user_script_env_field]     = formdata[self.user_script_env_field][0]
-            options[self.spark_cluster_field]       = formdata[self.spark_cluster_field][0] if self.spark_cluster_field in formdata.keys() else 'none'
-            options[self.condor_pool]               = formdata[self.condor_pool][0]
+            options[self.software_source]           = formdata[self.software_source][0]
             options[self.user_n_cores]              = int(formdata[self.user_n_cores][0])
             options[self.user_memory]               = formdata[self.user_memory][0] + 'G'
             options[self.use_jupyterlab_field]      = formdata.get(self.use_jupyterlab_field, 'unchecked')[0]
             options[self.use_local_packages_field]  = formdata.get(self.use_local_packages_field, 'unchecked')[0]
+            if options[self.software_source] == self.customenv_special_type:
+                options[self.builder]         = builder
+                options[self.builder_version] = builder_version
+                options[self.repository]      = formdata[self.repository][0]
+                options[self.repo_type]       = formdata[self.repo_type][0]
 
-            self.offload = options[self.spark_cluster_field] != 'none'
+                if not options[self.repository]:
+                    raise ValueError("No Repository specified")
+            else:
+                options[self.lcg_rel_field]         = formdata[self.lcg_rel_field][0]
+                options[self.platform_field]        = formdata[self.platform_field][0]
+                options[self.user_script_env_field] = formdata[self.user_script_env_field][0]
+                options[self.spark_cluster_field]   = formdata[self.spark_cluster_field][0]
+                options[self.condor_pool]           = formdata[self.condor_pool][0]
+
+                self.offload = options[self.spark_cluster_field] != 'none'
 
             return options
 
@@ -112,30 +140,23 @@ def define_SwanSpawner_from(base_class):
 
             #FIXME remove userrid and username and just use jovyan 
             #FIXME clean JPY env variables
-            if self.lcg_rel_field in self.user_options:
-                # session spawned via the form
+            env.update(dict(
+                USER                   = username,
+                NB_USER                = username,
+                USER_ID                = self.user_uid,
+                NB_UID                 = self.user_uid,
+                HOME                   = homepath,
+                EOS_PATH_FORMAT        = self.eos_path_format,
+                SERVER_HOSTNAME        = os.uname().nodename
+            ))
+
+            # Enable LCG-related variables
+            if self.user_options[self.software_source] == self.lcg_special_type:
                 env.update(dict(
-                    ROOT_LCG_VIEW_NAME     = self.user_options[self.lcg_rel_field],
-                    ROOT_LCG_VIEW_PLATFORM = self.user_options[self.platform_field],
-                    USER_ENV_SCRIPT        = self.user_options[self.user_script_env_field],
-                    ROOT_LCG_VIEW_PATH     = self.lcg_view_path,
-                    USER                   = username,
-                    NB_USER                = username,
-                    USER_ID                = self.user_uid,
-                    NB_UID                 = self.user_uid,
-                    HOME                   = homepath,
-                    EOS_PATH_FORMAT        = self.eos_path_format,
-                    SERVER_HOSTNAME        = os.uname().nodename
-                ))
-            else:
-                # session spawned via the API
-                env.update(dict(
-                    USER                   = "jovyan",
-                    HOME                   = "/home/jovyan",
-                    NB_USER                = 'jovyan',
-                    USER_ID                = 1000,
-                    NB_UID                 = 1000,
-                    SERVER_HOSTNAME        = os.uname().nodename,
+                    ROOT_LCG_VIEW_NAME       = self.user_options[self.lcg_rel_field],
+                    ROOT_LCG_VIEW_PLATFORM   = self.user_options[self.platform_field],
+                    USER_ENV_SCRIPT          = self.user_options[self.user_script_env_field],
+                    ROOT_LCG_VIEW_PATH       = self.lcg_view_path
                 ))
 
             # Enable JupyterLab interface
@@ -151,8 +172,10 @@ def define_SwanSpawner_from(base_class):
                 ))
 
             # Enable configuration for CERN HTCondor pool
-            if self.user_options[self.condor_pool] != 'none':
-                env['CERN_HTCONDOR'] = 'true'
+            if self.user_options.get(self.condor_pool, 'none') != 'none':
+                env.update(dict(
+                    CERN_HTCONDOR = 'true'
+                ))
 
             return env
 
@@ -210,7 +233,7 @@ def define_SwanSpawner_from(base_class):
             start_time_start_container = time.time()
             
             #if the user script exists, we allow extended timeout
-            if self.user_options[self.user_script_env_field].strip()!='':
+            if self.user_options.get(self.user_script_env_field, '').strip() != '':
                 self.start_timeout = self.extended_timeout
 
             # start configured container

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -112,8 +112,8 @@ def define_SwanSpawner_from(base_class):
                 options[self.repository]      = formdata[self.repository][0]
                 options[self.repo_type]       = formdata[self.repo_type][0]
 
-                if options[self.repository] is None or options[self.repository].strip() == '':
-                    raise ValueError('No Repository specified')
+                if options[self.repository] is None:
+                    raise ValueError('Cannot create custom software environment: no repository specified')
             else:
                 options[self.lcg_rel_field]         = formdata[self.lcg_rel_field][0]
                 options[self.platform_field]        = formdata[self.platform_field][0]

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -9,21 +9,19 @@
     var formInitialized = false;
 
     /**
-     * Get LCG data dictionary for given lcgValue.
+     * Get Form data dictionary for given selectedValue.
      */
-    function findLcgData(lcgValue) {
-        var lcgData;
-
-        // Data is taken from from lcgFormConfig global variable
-        var lcgFormOptions = lcgFormConfig['options'];
-        for (key in lcgFormOptions) {
-            lcgData = lcgFormOptions[key];
-            if (lcgData.type === "selection" && lcgData.lcg.value === lcgValue) {
-                return lcgData;
+    function findFormData(form, formElement, value) {
+        // Data is taken from formConfig global variable
+        var formOptions = formConfig[form];
+        for (key in formOptions) {
+            const formData = formOptions[key];
+            if (formData.type === "selection" && formData[formElement].value === value) {
+                return formData;
             }
         }
 
-        throw "LCG Data not found"
+        throw `${formElement} Data not found`
     }
 
     /**
@@ -38,10 +36,44 @@
     }
 
     /**
+     * Enable display of element if previously disabled, and disable if previously enabled
+     */
+     function validate_repository_input() {
+        var repoInput = document.getElementById('repositoryOption');
+        const repoPattern = new RegExp(repoInput.pattern);
+
+        if (repoInput.value && !repoPattern.test(repoInput.value)) {
+            repoInput.style.backgroundColor = '#ffcccc';
+        } else {
+            repoInput.style.backgroundColor = '#ffffff';
+        }
+    }
+
+    /**
      * Renders a form based on config file
      */
     function adjust_form() {
-        var selectLCG = document.getElementById('lcgReleaseOptions');
+        const sourceOptions = document.getElementsByName('software_source');
+        let selectedSource = null;
+        for (let i = 0; i < sourceOptions.length; i++) {
+            if (sourceOptions[i].checked) {
+                selectedSource = sourceOptions[i].value;
+                break;
+            }
+        }
+
+        var sourceConfig = {
+            lcg: {
+                optionsElement: document.getElementById("lcgReleaseOptions"),
+                sourceForm: "lcg_options",
+                formElement: "lcg",
+            },
+            customenv: {
+                optionsElement: document.getElementById("builderOptions"),
+                sourceForm: "customenv_options",
+                formElement: "builder",
+            }
+        };
 
         // if form has not been yet initialized, initialize
         if (!formInitialized) {
@@ -49,127 +81,78 @@
 
             // set proper header for the whole form based on config
             var optionsHeader = document.getElementById('optionsHeader');
-            var header = lcgFormConfig['header'];
+            var header = formConfig['header'];
             if (header) {
                 optionsHeader.innerHTML = header;
             }
 
-            // set LCG option in the rendered form - first LCG is default
-            var lcgFormOptions = lcgFormConfig['options'];
-            selectLCG.innerHTML = '';
-            var firstLCGSelected = false;
-            for( var i = 0 ; i < lcgFormOptions.length ; i++ ){
-                var lcgFormEntry = lcgFormOptions[i];
+            // Loop through all source types and populate the main dropdown options (lcg -> lcg_release, customenv -> builder)
+            for (var source in sourceConfig) {
+                const currentSource = sourceConfig[source];
+                const formOptions = formConfig[currentSource.sourceForm];
+                currentSource.optionsElement.innerHTML = '';
+                var firstFormOptionselected = false;
 
-                var selectLCGOption = document.createElement("option");
-                if (lcgFormEntry.type === "label") {
-                    selectLCGOption.disabled="disabled";
-                    selectLCGOption.style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0";
-                    selectLCGOption.value=lcgFormEntry.label.value;
-                    selectLCGOption.text=lcgFormEntry.label.text;
-                } else {
-                    if (!firstLCGSelected) {
-                        firstLCGSelected = true;
-                        selectLCGOption.selected = true;
+                for( var i = 0 ; i < formOptions.length ; i++ ){
+                    var formEntry = formOptions[i];
+                    var formOption = document.createElement("option");
+
+                    if (formEntry.type === "label") {
+                        formOption.disabled = "disabled";
+                        formOption.style = "border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0";
+                        formOption.value = formEntry.label.value;
+                        formOption.text = formEntry.label.text;
+                    } else {
+                        if (!firstFormOptionselected) {
+                            firstFormOptionselected = true;
+                            formOption.selected = true;
+                        }
+                        formOption.value = formEntry[currentSource.formElement].value;
+                        formOption.text = formEntry[currentSource.formElement].text;
                     }
-                    selectLCGOption.value=lcgFormEntry.lcg.value;
-                    selectLCGOption.text=lcgFormEntry.lcg.text;
+
+                    currentSource.optionsElement.add(formOption);
+                }
+            }
+        }
+
+        // get currently selected source and extract its configuration (formData)
+        const selectedConfig = sourceConfig[selectedSource];
+        var selectedValue = selectedConfig.optionsElement.value;
+        var formData = findFormData(selectedConfig.sourceForm, selectedConfig.formElement, selectedValue);
+
+        var available_configs = {
+            'lcg': [
+                {elementName: 'platformOptions', formKey: 'platforms'}, 
+                {elementName: 'coresOptions', formKey: 'cores'}, 
+                {elementName: 'memoryOptions', formKey: 'memory'}, 
+                {elementName: 'clusterOptions', formKey: 'clusters'}, 
+                {elementName: 'condorOptions', formKey: 'condor'}
+            ],
+            'customenv': [
+                {elementName: 'coresOptions', formKey: 'cores'},
+                {elementName: 'memoryOptions', formKey: 'memory'}
+            ]
+        };
+
+        // Populate the form according to main dropdown selection
+        available_configs[selectedSource].forEach(function(config) {
+            var configElement = document.getElementById(config.elementName);
+            configElement.innerHTML = '';
+
+            for( var i = 0 ; i < formData[config.formKey].length ; i++ ){
+                var formOption = formData[config.formKey][i];
+
+                var selectOption = document.createElement("option");
+                selectOption.value = formOption.value;
+                selectOption.text = formOption.text;
+                if (i === 0) {
+                    selectOption.selected = true;
                 }
 
-                selectLCG.add(selectLCGOption);
+                configElement.add(selectOption);
             }
-        }
-
-        // get currently selected LCG and extract that lcg configuration (lcgData)
-        var lcgValue = selectLCG.value;
-        var lcgData = findLcgData(lcgValue);
-
-        // adjust platforms option for lcg
-        var selectPlatform = document.getElementById('platformOptions');
-        selectPlatform.innerHTML = '';
-
-        for( var i = 0 ; i < lcgData.platforms.length ; i++ ){
-            var lcgPlatform = lcgData.platforms[i];
-
-            var selectPlatformOption = document.createElement("option");
-            selectPlatformOption.value = lcgPlatform.value;
-            selectPlatformOption.text = lcgPlatform.text;
-            if (i === 0) {
-                selectPlatformOption.selected = true;
-            }
-
-            selectPlatform.add(selectPlatformOption);
-        }
-
-        // adjust cores option for lcg
-        var selectCores = document.getElementById('coresOptions');
-        selectCores.innerHTML = '';
-
-        for( var i = 0 ; i < lcgData.cores.length ; i++ ){
-            var lcgCores = lcgData.cores[i];
-
-            var selectCoresOption = document.createElement("option");
-            selectCoresOption.value = lcgCores.value;
-            selectCoresOption.text = lcgCores.text;
-            if (i === 0) {
-                selectCoresOption.selected = true;
-            }
-
-            selectCores.add(selectCoresOption);
-        }
-
-        // adjust memory option for lcg
-        var selectMemory = document.getElementById('memoryOptions');
-        selectMemory.innerHTML = '';
-
-        for( var i = 0 ; i < lcgData.memory.length ; i++ ){
-            var lcgMemory = lcgData.memory[i];
-
-            var selectMemoryOption = document.createElement("option");
-            selectMemoryOption.value = lcgMemory.value;
-            selectMemoryOption.text = lcgMemory.text;
-            if (i === 0) {
-                selectMemoryOption.selected = true;
-            }
-
-            selectMemory.add(selectMemoryOption);
-        }
-
-        // adjust clusters option for lcg
-        var selectCluster = document.getElementById('clusterOptions');
-        selectCluster.innerHTML = '';
-        // Make sure Spark cluster options are enabled on LCG release change
-        selectCluster.removeAttribute('disabled');
-
-        for( var i = 0 ; i < lcgData.clusters.length ; i++ ){
-            var lcgCluster = lcgData.clusters[i];
-
-            var selectClusterOption = document.createElement("option");
-            selectClusterOption.value = lcgCluster.value;
-            selectClusterOption.text = lcgCluster.text;
-            if (i === 0) {
-                selectClusterOption.selected = true;
-            }
-
-            selectCluster.add(selectClusterOption);
-        }
-
-        // adjust condor option for lcg
-        var selectCondor = document.getElementById('condorOptions');
-        selectCondor.innerHTML = '';
-
-        for( var i = 0 ; i < lcgData.condor.length ; i++ ){
-            var lcgCondor = lcgData.condor[i];
-
-            var selectCondorOption = document.createElement("option");
-            selectCondorOption.value = lcgCondor.value;
-            selectCondorOption.text = lcgCondor.text;
-            if (i === 0) {
-                selectCondorOption.selected = true;
-            }
-
-            selectCondor.add(selectCondorOption);
-        }
+        });
 
         adjust_options();
     }
@@ -224,7 +207,61 @@
         }
     }
 
-    window.onload = adjust_form;
+    /**
+     * Adjusts the width of the repository type dropdown element based on the selected option
+     */
+     function adjust_repository_dropdown() {
+        const selectElement = document.getElementById('repo_type_dropdown');
+        const selectedOptionText = selectElement.options[selectElement.selectedIndex].text;
+        const tempElement = document.createElement('span');
+        tempElement.style.visibility = 'hidden';
+        tempElement.style.whiteSpace = 'nowrap';
+        tempElement.style.fontSize = window.getComputedStyle(selectElement).fontSize;
+        tempElement.innerHTML = selectedOptionText;
+
+        document.body.appendChild(tempElement);
+        const width = tempElement.offsetWidth;
+        document.body.removeChild(tempElement);
+
+        selectElement.style.width = `${width + 50}px`;
+
+        const repositoryOption = document.getElementById('repositoryOption');
+        if (selectElement.value === 'eos') {
+            repositoryOption.placeholder = 'e.g. $CERNBOX_HOME/MyFolder';
+            // Regular expression pattern for the repository provided by a EOS folder.
+            repositoryOption.pattern = '^(\\\$CERNBOX_HOME(\\/[^<>\|\\\\:()&;,\n]+)*\\/?|\\/eos\\/user\\/[a-z](\\/[^<>\|\\\\:()&;,\n]+)+\\/?)$';
+        } else if (selectElement.value === 'git') {
+            repositoryOption.placeholder= "e.g. https://gitlab.cern.ch/user/myrepo";
+            // Regular expression pattern for the repository provided by a GitLab or GitHub repository.
+            repositoryOption.pattern = '^https?:\\/\\/(?:github\\.com|gitlab\\.cern\\.ch)\\/([a-zA-Z0-9_-]+)\\/([a-zA-Z0-9_-]+)\\/?$';
+        }
+    }
+
+    /**
+     * Modifies the displayed form according to the selected type of configuration (LCG or Custom Environments)
+     */
+     function toggle_form() {
+        var lcgOption = document.getElementById('lcgOption');
+
+        var customenv_config = document.getElementById('customenv_config');
+        var external_res_config = document.getElementById('external_res_config');
+        var lcg_config = document.getElementById('lcg_config');
+
+        adjust_form();
+        if (lcgOption.checked) {
+            lcg_config.style.display = 'block';
+            customenv_config.style.display = 'none';
+            external_res_config.style.display = 'block';
+            adjust_spark();
+        } else {
+            adjust_repository_dropdown();
+            lcg_config.style.display = 'none';
+            customenv_config.style.display = 'block';
+            external_res_config.style.display = 'none';
+        } 
+    }
+
+    window.onload = toggle_form;
 //-->
 </script>
 <div>
@@ -251,68 +288,147 @@
       <span> Try the new JupyterLab interface (experimental)</span>
     </div>
     <br>
-    <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="lcgReleaseDetails">
-        <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
+
+    <!-- Source Type selection -->
+    <div id="software_sourceSection">
+        <h2>Software</h2>
+        <label>Source <a href="#" onclick="toggle_visibility('sourceDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="sourceDetails">
+                <span class='nb'>Software source: curated stack (LCG) or custom environment.</span>
+            </div>
+        </label>
         <br>
-        <span class='nb'>Additionally, it is possible to use Python packages installed by the user on CERNBox. More information <a target="_blank" href="https://swan.docs.cern.ch/advanced/install_packages/">here</a>.</span>
+        <input type="radio" id="lcgOption" name="software_source" value="lcg" checked onchange="toggle_form();" style="width: auto; height: auto; display: inline-block;">
+        <label for="lcgOption" style="margin-right: 5%;">LCG</label>
+        <input type="radio" id="customenvOption" name="software_source" value="customenv" onchange="toggle_form();" style="width: auto; height: auto; display: inline-block;">
+        <label for="customenvOption">Custom Environment</label>
+        <br><br>
     </div>
-    </label>
-    <select id="lcgReleaseOptions" name="LCG-rel" onchange="adjust_form();">
-    </select>
-    <div style="display: flex; align-items: center">
-        <input
-          id="use-local-packages"
-          type="checkbox"
-          name="use-local-packages"
-          value="checked"
-          style="display: inline; width: initial; margin: 0 8px 0 0"
-          onchange="adjust_platforms();"
-        />
-        <span> Use Python packages installed on CERNBox</span>
-      </div>
-    <br>
-    <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="platformDetails">
-       <span class='nb'>The combination of compiler version and flags.</span>
+
+    <!-- LCG configuration -->
+    <div id="lcg_config">
+        <div id="lcgReleaseSection">
+            <label for="lcgReleaseOptions">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="lcgReleaseDetails">
+                    <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
+                    <br>
+                    <span class='nb'>Additionally, it is possible to use Python packages installed by the user on CERNBox. More information <a target="_blank" href="https://swan.docs.cern.ch/advanced/install_packages/">here</a>.</span>
+                </div>
+            </label>
+            <select id="lcgReleaseOptions" name="LCG-rel" onchange="adjust_form();"></select>
+            <div style="display: flex; align-items: center">
+                <input
+                  id="use-local-packages"
+                  type="checkbox"
+                  name="use-local-packages"
+                  value="checked"
+                  style="display: inline; width: initial; margin: 0 8px 0 0"
+                  onchange="adjust_platforms();"
+                />
+                <span> Use Python packages installed on CERNBox</span>
+            </div>
+        </div>
+        <br>
+
+        <div id="platformSection">
+            <label for="platformOptions">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="platformDetails">
+                    <span class='nb'>The combination of compiler version and flags.</span>
+                </div>
+            </label>
+            <select id="platformOptions" name="platform" onchange="adjust_options();"></select>
+            <input type="hidden" id="hiddenPlatformOptions" name="platform">
+        </div>
+        <br>
+
+        <div id="scriptenvSection">
+            <label for="scriptenvOption">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="scriptenvDetails">
+                    <span class='nb'>User-provided bash script to define custom environment variables. The variable CERNBOX_HOME is resolved to the proper /eos/user/u/username directory.</span>
+                </div>
+            </label>
+            <input type="text" id="scriptenvOption" name="scriptenv" placeholder="e.g. $CERNBOX_HOME/MySWAN/myscript.sh">
+        </div>
+        <br>
     </div>
-    </label>
-    <select id="platformOptions" onchange="adjust_options();"></select>
-    <input type="hidden" id="hiddenPlatformOptions" name="platform">
-    <br>
-    <label for="scriptenvOption">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="scriptenvDetails">
-       <span class='nb'>User-provided bash script to define custom environment variables. The variable CERNBOX_HOME is resolved to the proper /eos/user/u/username directory.</span>
+
+    <!-- Custom environment configuration -->
+    <div id="customenv_config" style="display: none;">
+        <div id="repositorySection">
+            <label for="repositoryOption">Repository 
+                <a href="#" onclick="toggle_visibility('repositoryDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="repositoryDetails">
+                    <span class='nb'>Repository containing a requirements.txt file. It can be a path on EOS or the URL of a public git repository.</span>
+                </div>
+            </label>
+            <br>
+            <div style="display: flex;">
+                <select id="repo_type_dropdown" name="repo_type" onchange="adjust_repository_dropdown();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
+                    <option value="eos">EOS</option>
+                    <option value="git">Git</option>
+                </select>
+                <input type="text" id="repositoryOption" name="repository" style="flex-grow: 1; margin-left: 0; border: 1px solid #afafaf;" oninput="validate_repository_input();">
+            </div>
+        </div>
+        <br>
+
+        <div id="builderSection">
+            <label for="builderOptions">Builder <a href="#" onclick="toggle_visibility('builderDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="builderDetails">
+                    <span class='nb'>Program responsible for building the custom environment (generic or community-specific).</a></span>
+                </div>
+            </label>
+            <select id="builderOptions" name="builder"></select>
+        </div>
+        <br>
     </div>
-    </label>
-    <input type="text" id="scriptenvOption" name="scriptenv" placeholder="e.g. $CERNBOX_HOME/MySWAN/myscript.sh">
-    <br>
-    <label for="coresOptions">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="ncoresDetails">
-       <span class='nb'>Number of cores to associate to the container.</span>
+
+    <!-- Resources configuration -->
+    <div id="resources_config">
+        <h2>Session resources</h2>
+
+        <div id="coresSection">
+            <label for="coresOptions">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="ncoresDetails">
+                    <span class='nb'>Amount of cores allocated to the container.</span>
+                </div>
+            </label>
+            <select id="coresOptions" name="ncores"></select>
+        </div>
+        <br>
+
+        <div id="memorySection">
+            <label for="memoryOptions">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="memoryDetails">
+                    <span class='nb'>Amount of memory allocated to the container.</span>
+                </div>
+            </label>
+            <select id="memoryOptions" name="memory"></select>
+        </div>
+        <br>
     </div>
-    </label>
-    <select id="coresOptions" name="ncores"></select>
-    <br>
-    <label for="memoryOptions">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="memoryDetails">
-       <span class='nb'>Amount of Memory allocated to the container.</span>
+
+    <!-- External computing resources -->
+    <div id="external_res_config" style="display: block;">
+        <h2>External computing resources</h2>
+        
+        <div id="clusterSection">
+            <label for="clusterOptions">Spark cluster <a href="#" onclick="toggle_visibility('sparkClusterDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="sparkClusterDetails">
+                    <span class='nb'>Name of the Spark cluster to connect to from notebooks. See the <a target="_blank" href="https://hadoop-user-guide.web.cern.ch/">Hadoop User guide</a> and the <a target="_blank" href="https://sparktraining.web.cern.ch/">Spark training course</a></span>
+                </div>
+            </label>
+            <select id="clusterOptions" name="spark-cluster"></select>
+        </div>
+        <br>
+
+        <div id="condorSection">
+            <label for="condorOptions">HTCondor pool <a href="#" onclick="toggle_visibility('condorDetails');"><span class='nbs'>more...</span></a>
+                <div style="display:none;" id="condorDetails">
+                    <span class='nb'>Name of the HTCondor pool to use.</span>
+                </div>
+            </label>
+            <select id="condorOptions" name="condor-pool"></select>
+        </div>
     </div>
-    </label>
-    <select id="memoryOptions" name="memory"></select>
-    <br>
-    <h2 for="computing-resources">External computing resources</h2>
-    <label for="clusterOptions">Spark cluster <a href="#" onclick="toggle_visibility('sparkClusterDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="sparkClusterDetails">
-        <span class='nb'>Name of the Spark cluster to connect to from notebooks. See the <a target="_blank" href="https://hadoop-user-guide.web.cern.ch/">Hadoop User guide</a> and the <a target="_blank" href="https://sparktraining.web.cern.ch/">Spark training course</a></span>
-    </div>
-    </label>
-    <select id="clusterOptions" name="spark-cluster"></select>
-    <br>
-    <label for="condorOptions">HTCondor pool <a href="#" onclick="toggle_visibility('condorDetails');"><span class='nbs'>more...</span></a>
-    <div style="display:none;" id="condorDetails">
-        <span class='nb'>Name of the HTCondor pool to use.</span>
-    </div>
-    </label>
-    <select id="condorOptions" name="condor-pool"></select>
 </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -4,7 +4,7 @@
 <script type="text/javascript">
 <!--
 
-    var lcgFormConfig = {{ options_form_config }};
+    var formConfig = {{ options_form_config }};
 
     var formInitialized = false;
 


### PR DESCRIPTION
Result:
Spawner can now launch custom environments through its web interface.

Developments:
Thanks to changes on SwanSpawner and SwanHub, its now possible to avoid having to install all LCG packages and provide a specific amount of packages through cernbox/eos path or git repo containing a requirements.txt file.

This new custom virtual environment can then be launched by a generic python venv or a acc-py stack.

The user gets redirected to /customenv where the process details are shown up in real time, so the users is able to keep up with its going on under the hood. In the end, a completely empty custom environment (just with the provided packages) gets ready for the user to work on.