### PR TITLE
swanhub, swanspawner: New feature for notebook arguments

### DIFF
--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -31,7 +31,7 @@ class SpawnHandlersConfigs(SingletonConfigurable):
 
     user_script_env_field = 'scriptenv'
 
-    notebook = 'notebook'
+    file = 'file'
 
     use_jupyterlab_field = 'use-jupyterlab'
 

--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -31,6 +31,10 @@ class SpawnHandlersConfigs(SingletonConfigurable):
 
     user_script_env_field = 'scriptenv'
 
+    notebook = 'notebook'
+
+    use_jupyterlab_field = 'use-jupyterlab'
+
     customenv_special_type = 'customenv'
 
     accpy_special_type = 'accpy'

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -171,7 +171,7 @@ class SpawnHandler(JHSpawnHandler):
             query_params = {
                 "repo": options.get(configs.repository),
                 "repo_type": options.get(configs.repo_type),
-                "notebook": options.get(configs.notebook, ''),
+                "file": options.get(configs.file, ''),
             }
             if options.get(configs.builder) == configs.accpy_special_type:
                 query_params[options.get(configs.builder)] = options.get(configs.builder_version)
@@ -180,8 +180,8 @@ class SpawnHandler(JHSpawnHandler):
             next_url = url_concat(url_path_join("user", user.escaped_name, "customenvs", server_name), query_params)
         else: # LCG release
             next_url = url_path_join(self.hub.base_url, "spawn-pending", user.escaped_name, server_name)
-            if options.get(configs.notebook) and options[configs.use_jupyterlab_field] == 'checked':
-                next_url = url_path_join("user", user.escaped_name, "lab", "tree", *options[configs.notebook].split('/'))
+            if options.get(configs.file) and options[configs.use_jupyterlab_field] == 'checked':
+                next_url = url_path_join("user", user.escaped_name, "lab", "tree", *options[configs.file].split('/'))
 
         self.redirect(next_url)
 

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -54,6 +54,15 @@ class SpawnHandler(JHSpawnHandler):
             self.finish(form)
             return
 
+        # By default, the super().get() starts spawning the session if any
+        # query arguments are specified. So, we need to explicitly check for
+        # the software_source query argument to re-render the form and fulfill
+        # it with the remaining query arguments.
+        if configs.software_source in self.request.query_arguments:
+            form = await self._render_form_wrapper(user)
+            self.finish(form)
+            return
+
         try:
             await super().get(for_user, server_name)
         except web.HTTPError as e:
@@ -156,11 +165,13 @@ class SpawnHandler(JHSpawnHandler):
         if current_user is user:
             self.set_login_cookie(user)
 
+
         if options.get(configs.software_source) == configs.customenv_special_type:
             # Add the query parameters to the URL
             query_params = {
                 "repo": options.get(configs.repository),
                 "repo_type": options.get(configs.repo_type),
+                "notebook": options.get(configs.notebook, ''),
             }
             if options.get(configs.builder) == configs.accpy_special_type:
                 query_params[options.get(configs.builder)] = options.get(configs.builder_version)
@@ -169,6 +180,8 @@ class SpawnHandler(JHSpawnHandler):
             next_url = url_concat(url_path_join("user", user.escaped_name, "customenvs", server_name), query_params)
         else: # LCG release
             next_url = url_path_join(self.hub.base_url, "spawn-pending", user.escaped_name, server_name)
+            if options.get(configs.notebook) and options[configs.use_jupyterlab_field] == 'checked':
+                next_url = url_path_join("user", user.escaped_name, "lab", "tree", *options[configs.notebook].split('/'))
 
         self.redirect(next_url)
 

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -56,7 +56,7 @@ class SpawnHandler(JHSpawnHandler):
 
         # By default, the super().get() starts spawning the session if any
         # query arguments are specified. So, we need to explicitly check for
-        # the software_source query argument to re-render the form and fulfill
+        # the software_source query argument to re-render the form and fill
         # it with the remaining query arguments.
         if configs.software_source in self.request.query_arguments:
             form = await self._render_form_wrapper(user)

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -54,6 +54,8 @@ def define_SwanSpawner_from(base_class):
 
         condor_pool = 'condor-pool'
 
+        notebook = 'notebook'
+
         customenv_special_type = 'customenv'
 
         lcg_special_type = 'lcg'
@@ -106,6 +108,8 @@ def define_SwanSpawner_from(base_class):
             options[self.user_memory]               = formdata[self.user_memory][0] + 'G'
             options[self.use_jupyterlab_field]      = formdata.get(self.use_jupyterlab_field, 'unchecked')[0]
             options[self.use_local_packages_field]  = formdata.get(self.use_local_packages_field, 'unchecked')[0]
+            options[self.notebook]                  = formdata.get(self.notebook, '')[0]
+
             if options[self.software_source] == self.customenv_special_type:
                 options[self.builder]         = builder
                 options[self.builder_version] = builder_version

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -54,7 +54,7 @@ def define_SwanSpawner_from(base_class):
 
         condor_pool = 'condor-pool'
 
-        notebook = 'notebook'
+        file = 'file'
 
         customenv_special_type = 'customenv'
 
@@ -108,7 +108,7 @@ def define_SwanSpawner_from(base_class):
             options[self.user_memory]               = formdata[self.user_memory][0] + 'G'
             options[self.use_jupyterlab_field]      = formdata.get(self.use_jupyterlab_field, 'unchecked')[0]
             options[self.use_local_packages_field]  = formdata.get(self.use_local_packages_field, 'unchecked')[0]
-            options[self.notebook]                  = formdata.get(self.notebook, '')[0]
+            options[self.file]                      = formdata.get(self.file, '')[0]
 
             if options[self.software_source] == self.customenv_special_type:
                 options[self.builder]         = builder

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -40,7 +40,7 @@
     /**
      * Get the value of the first selectable option in the given select element
      */
-    function select_default_option(id) {
+    function get_default_option(id) {
         return document.getElementById(id).selectedOptions[0].value;
     }
     /**

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -46,7 +46,7 @@
     /**
      * Set the given input with the specified value
      */
-    function select_input(id, value) {
+    function set_input(id, value) {
         document.getElementById(id).value = value;
     }
     /**

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -8,6 +8,19 @@
 
     var formInitialized = false;
 
+    var sourceConfig = {
+        lcg: {
+            optionsElement: "lcgReleaseOptions",
+            sourceForm: "lcg_options",
+            formElement: "lcg",
+        },
+        customenv: {
+            optionsElement: "builderOptions",
+            sourceForm: "customenv_options",
+            formElement: "builder",
+        }
+    };
+
     /**
      * Get Form data dictionary for given selectedValue.
      */
@@ -25,6 +38,33 @@
     }
 
     /**
+     * Get the value of the first selectable option in the given select element
+     */
+    function select_default_option(id) {
+        return document.getElementById(id).selectedOptions[0].value;
+    }
+    /**
+     * Fulfill the given input with the specified value
+     */
+    function select_input(id, value) {
+        document.getElementById(id).value = value;
+    }
+    /**
+     * Loops throught the elements keys and selects the option with the given value
+     */
+    function select_options(elements) {
+        for (var id in elements) {
+            select_input(id, elements[id]);
+        }
+    }
+    /**
+     * (Un)check the element with the given id
+     */
+    function select_checkbox(id, checked) {
+        document.getElementById(id).checked = checked;
+    }
+
+    /**
      * Enable display of element if previously disabled, and disable if previously enabled
      */
     function toggle_visibility(id) {
@@ -38,7 +78,7 @@
     /**
      * Enable display of element if previously disabled, and disable if previously enabled
      */
-     function validate_repository_input() {
+    function validate_repository_input() {
         var repoInput = document.getElementById('repositoryOption');
         const repoPattern = new RegExp(repoInput.pattern);
 
@@ -53,27 +93,7 @@
      * Renders a form based on config file
      */
     function adjust_form() {
-        const sourceOptions = document.getElementsByName('software_source');
-        let selectedSource = null;
-        for (let i = 0; i < sourceOptions.length; i++) {
-            if (sourceOptions[i].checked) {
-                selectedSource = sourceOptions[i].value;
-                break;
-            }
-        }
-
-        var sourceConfig = {
-            lcg: {
-                optionsElement: document.getElementById("lcgReleaseOptions"),
-                sourceForm: "lcg_options",
-                formElement: "lcg",
-            },
-            customenv: {
-                optionsElement: document.getElementById("builderOptions"),
-                sourceForm: "customenv_options",
-                formElement: "builder",
-            }
-        };
+        let selectedSource = document.querySelector('input[name="software_source"]:checked').value;
 
         // if form has not been yet initialized, initialize
         if (!formInitialized) {
@@ -90,7 +110,7 @@
             for (var source in sourceConfig) {
                 const currentSource = sourceConfig[source];
                 const formOptions = formConfig[currentSource.sourceForm];
-                currentSource.optionsElement.innerHTML = '';
+                document.getElementById(currentSource.optionsElement).innerHTML = '';
                 var firstFormOptionselected = false;
 
                 for( var i = 0 ; i < formOptions.length ; i++ ){
@@ -111,14 +131,14 @@
                         formOption.text = formEntry[currentSource.formElement].text;
                     }
 
-                    currentSource.optionsElement.add(formOption);
+                    document.getElementById(currentSource.optionsElement).add(formOption);
                 }
             }
         }
 
         // get currently selected source and extract its configuration (formData)
         const selectedConfig = sourceConfig[selectedSource];
-        var selectedValue = selectedConfig.optionsElement.value;
+        var selectedValue = document.getElementById(selectedConfig.optionsElement).value;
         var formData = findFormData(selectedConfig.sourceForm, selectedConfig.formElement, selectedValue);
 
         var available_configs = {
@@ -210,8 +230,8 @@
     /**
      * Adjusts the width of the repository type dropdown element based on the selected option
      */
-     function adjust_repository_dropdown() {
-        const selectElement = document.getElementById('repo_type_dropdown');
+    function adjust_repo_typeOptions() {
+        const selectElement = document.getElementById('repo_typeOptions');
         const selectedOptionText = selectElement.options[selectElement.selectedIndex].text;
         const tempElement = document.createElement('span');
         tempElement.style.visibility = 'hidden';
@@ -246,19 +266,76 @@
         var customenv_config = document.getElementById('customenv_config');
         var external_res_config = document.getElementById('external_res_config');
         var lcg_config = document.getElementById('lcg_config');
+        var notebook_config = document.getElementById('notebook_config');
 
         adjust_form();
+
+        const urlParams = new URLSearchParams(window.location.search);
+        const software_source = urlParams.get('software_source');
+        const is_software_source_valid = software_source && Object.keys(sourceConfig).includes(software_source);
+        const query_map = {
+            checkboxes: {
+                "use-jupyterlab": 'use-jupyterlab',
+                "use-local-packages":'use-local-packages',
+            },
+            selectors: {
+                "ncores": "coresOptions",
+                "memory": "memoryOptions",
+                "LCG-rel": "lcgReleaseOptions",
+                "platform": "platformOptions",
+                "spark-cluster": "clusterOptions",
+                "condor-pool": "condorOptions",
+                "repo_type": "repo_typeOptions",
+                "builder": "builderOptions",
+            },
+            inputs: {
+                "scriptenv": "scriptenvOption",
+                "repository": "repositoryOption",
+                "notebook": "notebookOption",
+            },
+        }
+        if (is_software_source_valid) {
+            select_checkbox(`${software_source}Option`, true);
+            document.querySelectorAll('input[name="software_source"]:not(:checked)').forEach((elem) => elem.disabled = true);
+            for (const [param, elem] of Object.entries(query_map.checkboxes)) {
+                const checked = (urlParams.get(param) || "").toLowerCase() === 'true';
+                select_checkbox(elem, checked);
+            }
+            for (const [param, elem] of Object.entries(query_map.selectors)) {
+                const selected = urlParams.get(param) || select_default_option(elem);
+                select_input(elem, selected);
+            }
+            for (const [param, elem] of Object.entries(query_map.inputs)) {
+                const value = urlParams.get(param) || "";
+                select_input(elem, value);
+            }
+            notebook_config.style.display = 'block';
+        } else if (software_source && !is_software_source_valid) {
+            const error_message = document.createElement('span');
+            error_message.style.color = 'red';
+            error_message.innerHTML = `Invalid software source: ${software_source}`;
+            error_message.appendChild(document.createElement('br'));
+            const optionsHeader = document.getElementById('optionsHeader');
+            if (!optionsHeader.querySelector('span')) {
+                optionsHeader.insertBefore(error_message, optionsHeader.firstChild);
+            }
+        }
+
         if (lcgOption.checked) {
             lcg_config.style.display = 'block';
             customenv_config.style.display = 'none';
             external_res_config.style.display = 'block';
-            adjust_spark();
+
+            if (is_software_source_valid) {
+                adjust_options();
+                adjust_platforms();
+            }
         } else {
-            adjust_repository_dropdown();
+            adjust_repo_typeOptions();
             lcg_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_res_config.style.display = 'none';
-        } 
+        }
     }
 
     window.onload = toggle_form;
@@ -286,8 +363,8 @@
         onchange="adjust_platforms();"
       />
       <span> Try the new JupyterLab interface (experimental)</span>
+      <br>
     </div>
-    <br>
 
     <!-- Source Type selection -->
     <div id="software_sourceSection">
@@ -363,7 +440,7 @@
             </label>
             <br>
             <div style="display: flex;">
-                <select id="repo_type_dropdown" name="repo_type" onchange="adjust_repository_dropdown();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
+                <select id="repo_typeOptions" name="repo_type" onchange="adjust_repo_typeOptions();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
                     <option value="eos">EOS</option>
                     <option value="git">Git</option>
                 </select>
@@ -430,5 +507,18 @@
             </label>
             <select id="condorOptions" name="condor-pool"></select>
         </div>
+        <br>
+    </div>
+
+    <!-- Notebook path information text -->
+    <div id="notebook_config" style="display: none;">
+        <h2>Extra</h2>
+        <label for="notebookOption">Notebook path <a href="#" onclick="toggle_visibility('notebookDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="notebookDetails">
+                <span class='nb'>The path to the notebook that will be automatically opened when the session is launched.</span>
+            </div>
+        </label>
+        <input type="text" id="notebookOption" name="notebook">
+        <br>
     </div>
 </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -65,6 +65,20 @@
     }
 
     /**
+     * Build a simple error message on top of Header
+     */
+    function build_error_message(message) {
+        const error_message = document.createElement('span');
+        error_message.style.color = 'red';
+        error_message.innerHTML = message;
+        error_message.appendChild(document.createElement('br'));
+        const optionsHeader = document.getElementById('optionsHeader');
+        if (!optionsHeader.querySelector('span')) {
+            optionsHeader.insertBefore(error_message, optionsHeader.firstChild);
+        }
+    }
+
+    /**
      * Enable display of element if previously disabled, and disable if previously enabled
      */
     function toggle_visibility(id) {
@@ -311,14 +325,7 @@
             }
             notebook_config.style.display = 'block';
         } else if (software_source && !is_software_source_valid) {
-            const error_message = document.createElement('span');
-            error_message.style.color = 'red';
-            error_message.innerHTML = `Invalid software source: ${software_source}`;
-            error_message.appendChild(document.createElement('br'));
-            const optionsHeader = document.getElementById('optionsHeader');
-            if (!optionsHeader.querySelector('span')) {
-                optionsHeader.insertBefore(error_message, optionsHeader.firstChild);
-            }
+            build_error_message(`Invalid software source: ${software_source}`);
         }
 
         if (lcgOption.checked) {

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -54,7 +54,7 @@
      */
     function set_options(elements) {
         for (var id in elements) {
-            select_input(id, elements[id]);
+            set_input(id, elements[id]);
         }
     }
     /**
@@ -244,7 +244,7 @@
     /**
      * Adjusts the width of the repository type dropdown element based on the selected option
      */
-    function adjust_repo_typeOptions() {
+    function adjust_repo_type_options() {
         const selectElement = document.getElementById('repo_typeOptions');
         const selectedOptionText = selectElement.options[selectElement.selectedIndex].text;
         const tempElement = document.createElement('span');
@@ -280,7 +280,6 @@
         var customenv_config = document.getElementById('customenv_config');
         var external_res_config = document.getElementById('external_res_config');
         var lcg_config = document.getElementById('lcg_config');
-        var notebook_config = document.getElementById('notebook_config');
 
         adjust_form();
 
@@ -305,26 +304,28 @@
             inputs: {
                 "scriptenv": "scriptenvOption",
                 "repository": "repositoryOption",
-                "notebook": "notebookOption",
+                "file": "fileOption",
             },
         }
         if (is_software_source_valid) {
-            select_checkbox(`${software_source}Option`, true);
+            set_checkbox(`${software_source}Option`, true);
             document.querySelectorAll('input[name="software_source"]:not(:checked)').forEach((elem) => elem.disabled = true);
             for (const [param, elem] of Object.entries(query_map.checkboxes)) {
                 const checked = (urlParams.get(param) || "").toLowerCase() === 'true';
-                select_checkbox(elem, checked);
+                set_checkbox(elem, checked);
             }
             for (const [param, elem] of Object.entries(query_map.selectors)) {
-                const selected = urlParams.get(param) || select_default_option(elem);
-                select_input(elem, selected);
+                const selected = urlParams.get(param) || get_default_option(elem);
+                set_input(elem, selected);
             }
             for (const [param, elem] of Object.entries(query_map.inputs)) {
                 const value = urlParams.get(param) || "";
-                select_input(elem, value);
+                set_input(elem, value);
             }
-            notebook_config.style.display = 'block';
-        } else if (software_source && !is_software_source_valid) {
+            if (urlParams.get('file') !== null  && urlParams.get('file') !== '') {
+                toggle_visibility('file_config');
+            }
+        } else {
             build_error_message(`Invalid software source: ${software_source}`);
         }
 
@@ -338,7 +339,7 @@
                 adjust_platforms();
             }
         } else {
-            adjust_repo_typeOptions();
+            adjust_repo_type_options();
             lcg_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_res_config.style.display = 'none';
@@ -447,7 +448,7 @@
             </label>
             <br>
             <div style="display: flex;">
-                <select id="repo_typeOptions" name="repo_type" onchange="adjust_repo_typeOptions();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
+                <select id="repo_typeOptions" name="repo_type" onchange="adjust_repo_type_options();" style="width: auto; display: inline-flex; border: 1px solid #afafaf; background-color: #efefef;">
                     <option value="eos">EOS</option>
                     <option value="git">Git</option>
                 </select>
@@ -517,15 +518,15 @@
         <br>
     </div>
 
-    <!-- Notebook path information text -->
-    <div id="notebook_config" style="display: none;">
-        <h2>Extra</h2>
-        <label for="notebookOption">Notebook path <a href="#" onclick="toggle_visibility('notebookDetails');"><span class='nbs'>more...</span></a>
-            <div style="display:none;" id="notebookDetails">
-                <span class='nb'>The path to the notebook that will be automatically opened when the session is launched.</span>
+    <!-- File path information text -->
+    <div id="file_config" style="display: none;">
+        <h2>Open File</h2>
+        <label for="fileOption">File path <a href="#" onclick="toggle_visibility('fileDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="fileDetails">
+                <span class='nb'>Relative path of the file to be opened after the session is launched. For EOS repositories, it is relative to CERNBOX_HOME; for Git repositories, it is relative to the repository root.</span>
             </div>
         </label>
-        <input type="text" id="notebookOption" name="notebook">
+        <input type="text" id="fileOption" name="file">
         <br>
     </div>
 </div>

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -44,7 +44,7 @@
         return document.getElementById(id).selectedOptions[0].value;
     }
     /**
-     * Fulfill the given input with the specified value
+     * Set the given input with the specified value
      */
     function select_input(id, value) {
         document.getElementById(id).value = value;

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -60,7 +60,7 @@
     /**
      * (Un)check the element with the given id
      */
-    function select_checkbox(id, checked) {
+    function set_checkbox(id, checked) {
         document.getElementById(id).checked = checked;
     }
 

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -52,7 +52,7 @@
     /**
      * Loops throught the elements keys and selects the option with the given value
      */
-    function select_options(elements) {
+    function set_options(elements) {
         for (var id in elements) {
             select_input(id, elements[id]);
         }


### PR DESCRIPTION
Spawner can now use GET for getting the same arguments it gets through POST requests. With this, an URL that includes a `notebook` argument can open it after launching a session with the remaining specified parameters. If it is a customenv session, it just forwards the `notebook` argument to the SwanCustomEnvironments extension and this will take care of the rest.