### PR TITLE
swanhub: new `conda` builder option

### DIFF
--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -37,8 +37,6 @@ class SpawnHandlersConfigs(SingletonConfigurable):
 
     customenv_special_type = 'customenv'
 
-    accpy_special_type = 'accpy'
-
     local_home = Bool(
         default_value=False,
         config=True,

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -171,10 +171,12 @@ class SpawnHandler(JHSpawnHandler):
             query_params = {
                 "repo": options.get(configs.repository),
                 "repo_type": options.get(configs.repo_type),
+                "builder": options.get(configs.builder),
                 "file": options.get(configs.file, ''),
             }
-            if options.get(configs.builder) == configs.accpy_special_type:
-                query_params[options.get(configs.builder)] = options.get(configs.builder_version)
+            # If the builder has a version, pass it as an argument of the query
+            if options.get(configs.builder_version):
+                query_params["builder_version"] = options[configs.builder_version]
 
             # Execution SwanCustomEnvs extension with the corresponding query arguments
             next_url = url_concat(url_path_join("user", user.escaped_name, "customenvs", server_name), query_params)

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -113,7 +113,7 @@ def define_SwanSpawner_from(base_class):
                 if not options[self.repository]:
                     raise ValueError('Cannot create custom software environment: no repository specified')
 
-                # Builders are specified in builder:builderversion format (e.g. swan:1.0)
+                # Builders can have a version or not. When they do, we receive the following text from the form: builder:builder_version
                 raw_builder = formdata.get(self.builder, [''])[0].lower()
                 if raw_builder.count(':') == 1:
                     options[self.builder], options[self.builder_version] = raw_builder.split(':')

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -113,10 +113,12 @@ def define_SwanSpawner_from(base_class):
                 if not options[self.repository]:
                     raise ValueError('Cannot create custom software environment: no repository specified')
 
-                # Builders are specified in builder-builderversion format
-                builder, builder_version = formdata[self.builder][0].lower().split('-')
-                options[self.builder]         = builder
-                options[self.builder_version] = builder_version
+                # Builders are specified in builder:builderversion format (e.g. swan:1.0)
+                raw_builder = formdata.get(self.builder, [''])[0].lower()
+                if raw_builder.count(':') == 1:
+                    options[self.builder], options[self.builder_version] = raw_builder.split(':')
+                else:
+                    options[self.builder] = raw_builder
             else:
                 options[self.lcg_rel_field]         = formdata[self.lcg_rel_field][0]
                 options[self.platform_field]        = formdata[self.platform_field][0]

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -325,7 +325,7 @@
             if (urlParams.get('file') !== null  && urlParams.get('file') !== '') {
                 toggle_visibility('file_config');
             }
-        } else {
+        } else if (software_source !== null) {
             build_error_message(`Invalid software source: ${software_source}`);
         }
 


### PR DESCRIPTION
Swanhub can now also forward `conda` builder option through URL param to `SwanCustomEnvironments` extension