### PR TITLE
[SwanHub] Update jupyterhub version to 4.1.6

### DIFF
--- a/SwanHub/setup.py
+++ b/SwanHub/setup.py
@@ -22,7 +22,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     install_requires=[
-          'jupyterhub~=4.0.2'
+          'jupyterhub~=4.1.6'
     ],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Because of https://github.com/jupyterhub/jupyterhub/issues/4629.