### PR TITLE
[SwanSpawner] Fix local home path

### DIFF
--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -103,7 +103,7 @@ def define_SwanSpawner_from(base_class):
 
             username = self.user.name
             if self.local_home:
-                homepath = "/scratch/%s" %(username)
+                homepath = "/home/%s" %(username)
             else:
                 homepath = self.eos_path_format.format(username = username)
 


### PR DESCRIPTION
The alma9 image uses /home/user and not /scratch/user anymore.