### PR TITLE
swanspawner: Fix `use-jupyterlab` and recover `file`

### DIFF
--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -54,6 +54,8 @@ def define_SwanSpawner_from(base_class):
 
         condor_pool = 'condor'
 
+        file = 'file'
+
         customenv_special_type = 'customenv'
 
         lcg_special_type = 'lcg'
@@ -137,6 +139,8 @@ def define_SwanSpawner_from(base_class):
             options[self.user_n_cores]              = formdata[self.user_n_cores][0]
             options[self.user_memory]               = formdata[self.user_memory][0]
             options[self.use_jupyterlab_field]      = formdata.get(self.use_jupyterlab_field, 'unchecked')[0]
+            # File to be opened when the session gets started (specified only as query parameter)
+            options[self.file]                      = formdata.get(self.file, [''])[0]
 
             if options[self.software_source] == self.customenv_special_type:
                 options[self.repo_type]       = formdata[self.repo_type][0]

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -7,6 +7,7 @@
     var formConfig = {{ options_form_config }};
 
     var formInitialized = false;
+    var previous_jupyterlab = undefined;
 
     var sourceConfig = {
         lcg: {
@@ -334,18 +335,18 @@
             lcg_config.style.display = 'block';
             customenv_config.style.display = 'none';
             external_res_config.style.display = 'block';
-            jupyterLabOption.checked = false;
-            jupyterLabOption.removeAttribute('disabled');
-
             if (is_software_source_valid) {
                 adjust_options();
-                adjust_platforms();
+            } else {
+                jupyterLabOption.checked = previous_jupyterlab;
             }
+            adjust_platforms();
         } else {
             adjust_repo_type_options();
             lcg_config.style.display = 'none';
             customenv_config.style.display = 'block';
             external_res_config.style.display = 'none';
+            previous_jupyterlab = jupyterLabOption.checked;
             jupyterLabOption.checked = true;
             jupyterLabOption.setAttribute('disabled', '');
         }


### PR DESCRIPTION
Fix visual effects of the checkbox when the user provides the value via query args or changes form between software_source
`file` options is used for opening a file when the session gets started. It works for both lcg and customenvs sessions.