### PR TITLE
KeyCloakAuthenticator: switch "redirect_uri" for "post_logout_redirect_uri" in logout config

### DIFF
--- a/KeyCloakAuthenticator/keycloakauthenticator/auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/auth.py
@@ -165,7 +165,8 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
                 end_session_url = data.get('end_session_endpoint')
                 if self.enable_logout and end_session_url:
                     if self.logout_redirect_url:
-                        end_session_url += '?redirect_uri=%s' % self.logout_redirect_url
+                        end_session_url += '?post_logout_redirect_uri=%s' % self.logout_redirect_url
+                        end_session_url += '&client_id=%s' % self.client_id
                     # Update parent class OAuthenticator.logout_redirect_url
                     self.logout_redirect_url = end_session_url 
 


### PR DESCRIPTION
"?redirect_uri=[...]" in the logout redirect is deprecated in the current version of Keycloak and needs a legacy compatibility mode to be enabled to support it (see https://github.com/swan-cern/jupyterhub-extensions/issues/125).

This commit switches that out for "?post_logout_redirect_uri=[...]&client_id=[client_id]", which is supported for logout URIs in OIDC: https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout