### PR TITLE
swanspawner: Fix nxcals selector

### DIFF
--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -343,6 +343,12 @@
         } else {
             previous_jupyterlab = jupyterLabOption.checked;
             adjust_clusters(external_res_config, condorSection, lcg_config, customenv_config, jupyterLabOption);
+            if (is_software_source_valid) {
+                for (const [param, elem] of Object.entries(query_map.selectors)) {
+                    const selected = urlParams.get(param) || get_default_option(elem);
+                    set_input(elem, selected);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
NXCals selector was not being updated with its value passed as query argument because the moment it was being fulfilled, the options weren't loaded yet.