### PR TITLE
Swan on tn preventions

### DIFF
--- a/SwanHub/swanhub/templates/spawn_conflict.html
+++ b/SwanHub/swanhub/templates/spawn_conflict.html
@@ -1,0 +1,57 @@
+{% extends "page.html" %}
+
+{% block main %}
+<style>
+  .btn-secondary {color: white; background-color: #fc6404;}
+  .btn-secondary:hover {color: white; background-color: #e64a00;}
+</style>
+
+<div class="container">
+  <div class="row">
+    <div class="swan-info">
+      <div id="swan-loader">
+        <div class="loader-circle">
+          <img src="{{ static_url('swan/logos/' + swan_logo_filename) }}">
+        </div>
+        <div class="loader-line-mask" hidden>
+          <div class="loader-line"></div>
+        </div>
+        <span class="text">
+          <p class="extra">
+            A session with is running already. Do you want to stop it or go to it?
+          </p>
+          <div class="extra" id="swan-options">
+            <button type="button" class="btn btn-secondary">Stop session</button>
+            <button type="button" class="btn btn-primary">JupyterLab</button>
+          </div>
+        </span>
+      </div>
+    </div>
+    <br><br>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block script %}
+{{ super() }}
+<script type="text/javascript">
+require(["jquery"], function ($) {
+  $("#refresh").click(function () {
+    window.location.reload();
+  });
+  setTimeout(function () {
+    window.location.reload();
+  }, 5000);
+
+  $('#swan-options .btn-secondary').on('click', function() {
+    window.location = '{{base_url}}home?changeconfig';
+  });
+
+  $('#swan-options .btn-primary').on('click', function() {
+    window.location = '{{base_url}}'.split('/')[0] + "{{ next_url }}";
+  });
+});
+
+</script>
+{% endblock %}

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -603,7 +603,7 @@
     </div>
 
     <!-- External computing resources -->
-    <div id="external_res_config" style="display: block;">
+    <div id="external_res_config">
         <h2>External computing resources</h2>
         
         <div id="clusterSection">
@@ -628,7 +628,7 @@
     </div>
 
     <!-- Extra Options -->
-    <div id="extra_options_config" style="display: block;">
+    <div id="extra_options_config">
         <!-- Toggle Extra Options Section -->
         <h2 role="button" onclick="toggle_extra_options('extra_options');" style="display: flex; align-items: center; text-decoration: none;"><span id="extra_options">‣</span>Extra options</h2>
 

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -623,8 +623,8 @@
                 </div>
             </label>
             <select id="condorOptions" name="condor"></select>
+            <br>
         </div>
-        <br>
     </div>
 
     <!-- Extra Options -->


### PR DESCRIPTION
Hide breakline properly, in order to keep the space balanced between fields
After opening a new tab on top of a running session: spawn-pending -> dialog modal to allow the user to access the current session or shut it down
If the current session is lcg: forward the user directly to the JupyterLab
If it is a customenv: forward him to the extension page in order to get the creation progress of the environment

*\*before\**
![image](https://github.com/user-attachments/assets/ba7c8efa-1762-479b-a918-6741cefecd23)

*\*currently\**
<img width="952" alt="image" src="https://github.com/user-attachments/assets/19a3c060-67d7-4a0e-84fe-9811c3a5ba04" />
