### PR TITLE
swanhub: Fix redirect back to form

### DIFF
--- a/SwanHub/swanhub/templates/home.html
+++ b/SwanHub/swanhub/templates/home.html
@@ -115,6 +115,7 @@
 
     var urlParams = new URLSearchParams(window.location.search);
     if (urlParams.has('changeconfig')) {
+      urlParams.delete('changeconfig');
 
       $('#swan-loader .text').text('Shutting down your session');
 
@@ -124,7 +125,7 @@
 
       api.stop_server(user, {
         success: function () {
-          window.location.replace('{{base_url}}spawn');
+          window.location.replace('{{base_url}}spawn?' + urlParams.toString());
         },
         error: function () {
           $('#swan-loader .text').html('<p class="extra">There was an error shutting down your session.<br>Try again later.<br><a href="{{base_url}}">Click here to return to SWAN</a></p>');

--- a/SwanHub/swanhub/templates/spawn_conflict.html
+++ b/SwanHub/swanhub/templates/spawn_conflict.html
@@ -45,7 +45,7 @@ require(["jquery"], function ($) {
   }, 5000);
 
   $('#swan-options .btn-secondary').on('click', function() {
-    window.location = '{{base_url}}home?changeconfig';
+    window.location = `{{base_url}}home?changeconfig&${window.location.href.split('?')[1]}`;
   });
 
   $('#swan-options .btn-primary').on('click', function() {

--- a/SwanHub/swanhub/templates/spawn_conflict.html
+++ b/SwanHub/swanhub/templates/spawn_conflict.html
@@ -18,7 +18,7 @@
         </div>
         <span class="text">
           <p class="extra">
-            A session with is running already. Do you want to stop it or go to it?
+            A session is running already. Do you want to stop it or go to it?
           </p>
           <div class="extra" id="swan-options">
             <button type="button" class="btn btn-secondary">Stop session</button>


### PR DESCRIPTION
Change info message for `spawn_conflict` page
Reuse query arguments for redirecting the user back to the form with all options specified initially
