### PR TITLE
swanhub: Prevent absence of query_params when redirecting the user back to the form

### DIFF
--- a/SwanHub/swanhub/templates/spawn_conflict.html
+++ b/SwanHub/swanhub/templates/spawn_conflict.html
@@ -45,7 +45,8 @@ require(["jquery"], function ($) {
   }, 5000);
 
   $('#swan-options .btn-secondary').on('click', function() {
-    window.location = `{{base_url}}home?changeconfig&${window.location.href.split('?')[1]}`;
+    const query_params = window.location.href.split('?')[1];
+    window.location = '{{base_url}}home?changeconfig' + (query_params ? '&' + query_params : '');
   });
 
   $('#swan-options .btn-primary').on('click', function() {


### PR DESCRIPTION
Avoid redirections like `https://<domain>.cern.ch/hub/home?changeconfig&undefined=`, which pops up an incorrect error message