### PR TITLE
Display error on session start if env script path does not exist

### DIFF
--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -200,6 +200,14 @@ def define_SwanSpawner_from(base_class):
                     value_cleaned
                 )
 
+                if int(value_cleaned) == 127:
+                    self.log.warning(
+                        "Detected user environment script setup failure (exit code 127)")
+                    raise RuntimeError(
+                        f"User environment script failed: "
+                        f"Could not find the script '{self.user_options[self.user_script_env_field]}'."
+                    )
+
             return container_exit_code
 
         async def start(self):


### PR DESCRIPTION
Add error at the top of the user form:
<img width="440" alt="Screenshot 2025-04-08 at 13 53 59" src="https://github.com/user-attachments/assets/b6e93d53-894f-465e-99bd-21349b1a063f" />
