### PR TITLE
swanspawner: New option to redirect to the TN

### DIFF
--- a/SwanHub/swanhub/handlers_configs.py
+++ b/SwanHub/swanhub/handlers_configs.py
@@ -33,7 +33,15 @@ class SpawnHandlersConfigs(SingletonConfigurable):
 
     use_jupyterlab_field = 'use-jupyterlab'
 
+    use_tn = 'use-tn'
+
     customenv_special_type = 'customenv'
+
+    tn_enabled = Bool(
+        default_value=False,
+        config=True,
+        help="True if this SWAN deployment is exposed to the Technical Network."
+    )
 
     local_home = Bool(
         default_value=False,

--- a/SwanHub/swanhub/spawn_handler.py
+++ b/SwanHub/swanhub/spawn_handler.py
@@ -245,6 +245,7 @@ class SpawnHandler(JHSpawnHandler):
                                         self.request.uri, {"_xsrf": self.xsrf_token.decode('ascii')}
                                     ),
                                     spawner=for_user.spawner,
+                                    tn_enabled=configs.tn_enabled,
                                     save_config=save_config
                                     )
 

--- a/SwanHub/swanhub/templates/spawn.html
+++ b/SwanHub/swanhub/templates/spawn.html
@@ -73,6 +73,9 @@
       keyboard: false
     });
 
+    // Fill the checkbox if this is a cluster exposed to the TN
+    $('#use-tn').prop('checked', '{{ tn_enabled }}' === 'True');
+
     $('#spawn').on('click', function (e) {
       const form = document.getElementById('spawn_form');
 

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -65,6 +65,18 @@ def define_SwanSpawner_from(base_class):
             help='Path to configuration file for options_form rendering.'
         )
 
+        general_domain_name = Unicode(
+            default_value='swan.cern.ch',
+            config=True,
+            help='Domain name of the general SwanHub instance.'
+        )
+
+        ats_domain_name = Unicode(
+            default_value='ats.swan.cern.ch',
+            config=True,
+            help='Domain name of the ATS SwanHub instance.'
+        )
+
         lcg_view_path = Unicode(
             default_value='/cvmfs/sft.cern.ch/lcg/views',
             config=True,
@@ -314,7 +326,7 @@ def define_SwanSpawner_from(base_class):
                 with open(self.options_form_config) as yaml_file:
                     options_form_config = yaml.safe_load(yaml_file)
 
-                return template.render(options_form_config=options_form_config)
+                return template.render(options_form_config=options_form_config, general_domain_name=self.general_domain_name, ats_domain_name=self.ats_domain_name)
             except Exception as ex:
                 self.log.error("Could not initialize form: %s", ex, exc_info=True)
                 raise RuntimeError(

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -383,7 +383,8 @@
     function autofillURLParams(url_params, selected_source) {
         // Fill all checkboxes first (including the software source)
         for (const [argument, element] of Object.entries(query_map[selected_source].checkboxes)) {
-            let checked = (url_params.get(argument) || "").toLowerCase() === 'true';
+            const previous_value = `${document.getElementById(element).checked}`;
+            let checked = (url_params.get(argument) || previous_value).toLowerCase() === 'true';
             // Force the selection of the correct software source
             if (argument === 'use-'+selected_source) checked = true;
             if (argument === 'use-jupyterlab' && selected_source === lcg_source) previous_jupyterlab = checked;

--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -60,6 +60,7 @@
         "use-jupyterlab": [lcg_source, customenv_source],
         [`use-${lcg_source}`]: [lcg_source, customenv_source],
         [`use-${customenv_source}`]:[lcg_source, customenv_source],
+        "use-tn": [lcg_source, customenv_source],
     };
     const selectors = {
         [lcg_parent_field]: [lcg_source],
@@ -226,6 +227,16 @@
                 tooltip.style.backgroundColor = '#333';
             }, 3000);
         });
+    }
+
+    /**
+     * Redirect to the TN access page, preserving all URL parameters
+     */
+    function accessTN(checked) {
+        const url_params = (new URLSearchParams(window.location.search)).toString();
+        console.log(url_params);
+        const next_url = checked ? '{{ ats_domain_name }}' : '{{ general_domain_name }}';
+        window.location.host = `${next_url}/hub/spawn${url_params ? `?${url_params}` : ''}`;
     }
 
     /**
@@ -617,6 +628,19 @@
             <select id="builderOptions" name="builder" onchange="adjustForm(customenv_source);" required></select>
         </div>
         <br>
+    </div>
+
+    <div id="network_config" style="margin-bottom: 30px;">
+        <h2>Network</h2>
+
+        <div id="tnSection">
+            <input type="checkbox" id="use-tn" name="use-tn" onchange="accessTN(this.checked);" style="width: auto; height: auto; display: inline-block;">
+            <label style="width: auto; height: auto; display: inline-block;" for="use-tn">TN Access</label>
+            <a href="#" onclick="toggleVisibility('use-tnDetails');"><span class='nbs'>more...</span></a>
+            <div style="display:none;" id="use-tnDetails">
+                <span class='nb'>Request a user session that is exposed to the CERN Technical Network.</span>
+            </div>
+        </div>
     </div>
 
     <!-- Resources configuration -->


### PR DESCRIPTION
When filling this checkbox, the user will be redirected to another cluster that is exposed to the TN, preserving all of the originally specified url params.
Also, when `tn_enabled` is defined, the value specified in `spawn.html` for `use-tn` checkbox needs to be preserved.
