### PR TITLE
swanspawner: Prevent against not specified `customenv_options`

### DIFF
--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -320,7 +320,7 @@
         // Loop through all source types and populate the main dropdown options (lcg -> lcg_release, customenv -> builder)
         for (const [source, source_data] of Object.entries(source_config)) {
             let first_form_optionselected = false;
-            const form_options = form_config[source_data.source_form];
+            const form_options = form_config[source_data.source_form] || [];
             const current_element = document.getElementById(source_data.options_element);
             current_element.innerHTML = '';
 


### PR DESCRIPTION
Frontend failed if both `lcg_optons` and `customenv_options` weren't specified, leaving all fields blank. Now it ignores non specified values, avoid errors and filling only the provided ones.