### PR TITLE
swanhub: Tick checkbox when form is loaded

### DIFF
--- a/SwanHub/swanhub/templates/spawn.html
+++ b/SwanHub/swanhub/templates/spawn.html
@@ -73,11 +73,6 @@
       keyboard: false
     });
 
-    // Fill the checkbox if this is a cluster exposed to the TN
-    window.onpageshow = (event) => {
-      // This is a back-forward navigation
-      document.getElementById('use-tn').checked = '{{ tn_enabled }}' === 'True';
-    };
 
     $('#spawn').on('click', function (e) {
       const form = document.getElementById('spawn_form');
@@ -91,6 +86,11 @@
 
     modal.on('shown.bs.modal', function () {
       $('#spawn').focus();
+
+      // Fill the checkbox if this is a cluster exposed to the TN
+      const tnCheckbox = document.getElementById('use-tn');
+      if (tnCheckbox) tnCheckbox.checked = '{{ tn_enabled }}' === 'True';
+      else console.warn("'use-tn' is not defined, cannot set use-tn checkbox");
     });
 
     modal.on('hidden.bs.modal', function () {


### PR DESCRIPTION
When the template is rendered, first the page is loaded, then is the form. For this reason, the checkbox must be ticked only when the modal is ready, when the `use-tn` can be correctly found. A warning message is also added if it doesn't get found, for debugging purposes.