### PR TITLE
swanspawner: Preserve correctness of `use-jupyterlab` checkbox

### DIFF
--- a/SwanSpawner/swanspawner/templates/options_form_template.html
+++ b/SwanSpawner/swanspawner/templates/options_form_template.html
@@ -411,7 +411,10 @@
             let checked = (url_args.get(argument) || previous_value).toLowerCase() === 'true';
             // Force the selection of the correct software source
             if (argument === 'use-'+selected_source) checked = true;
-            if (argument === 'use-jupyterlab' && selected_source === lcg_source) previous_jupyterlab = checked;
+            if (argument === 'use-jupyterlab') {
+                if (selected_source === customenv_source) checked = true;
+                else previous_jupyterlab = checked;
+            }
             setCheckbox(element, checked);
         }
 


### PR DESCRIPTION
Keep `use-jupyterlab` ticked even when a wrong url value is provided for customenvs