### PR TITLE
swanhub: Fix user redirection

### DIFF
--- a/SwanHub/swanhub/templates/spawn_conflict.html
+++ b/SwanHub/swanhub/templates/spawn_conflict.html
@@ -43,7 +43,7 @@ require(["jquery"], function ($) {
   });
 
   $('#swan-options .btn-primary').on('click', function() {
-    window.location = '{{base_url}}'.split('/')[0] + "{{ next_url }}";
+    window.location.replace(window.location.origin + "/{{ next_url }}");
   });
 });
 

--- a/SwanHub/swanhub/templates/spawn_conflict.html
+++ b/SwanHub/swanhub/templates/spawn_conflict.html
@@ -37,13 +37,6 @@
 {{ super() }}
 <script type="text/javascript">
 require(["jquery"], function ($) {
-  $("#refresh").click(function () {
-    window.location.reload();
-  });
-  setTimeout(function () {
-    window.location.reload();
-  }, 5000);
-
   $('#swan-options .btn-secondary').on('click', function() {
     const query_params = window.location.href.split('?')[1];
     window.location = '{{base_url}}home?changeconfig' + (query_params ? '&' + query_params : '');

--- a/SwanHub/swanhub/templates/spawn_conflict.html
+++ b/SwanHub/swanhub/templates/spawn_conflict.html
@@ -38,8 +38,8 @@
 <script type="text/javascript">
 require(["jquery"], function ($) {
   $('#swan-options .btn-secondary').on('click', function() {
-    const query_params = window.location.href.split('?')[1];
-    window.location = '{{base_url}}home?changeconfig' + (query_params ? '&' + query_params : '');
+    const query_params = window.location.search ? '&' + window.location.search.substring(1) : '';
+    window.location.replace('{{base_url}}home?changeconfig' + query_params);
   });
 
   $('#swan-options .btn-primary').on('click', function() {


### PR DESCRIPTION
The use of `{{base_url}}` may sometimes inject `/hub/spawn` as `next_url`, which can lead to 404 errors. This implementation clears that up, ensuring it always goes to the given `next_url`