### PR TITLE
KeyCloakAuthenticator: Add "subject_token_type" to token exchange

### DIFF
--- a/KeyCloakAuthenticator/keycloakauthenticator/auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/auth.py
@@ -215,7 +215,8 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
                 client_secret = self.client_secret,
                 subject_token = token,
                 audience = service_name,
-                requested_token_type = 'urn:ietf:params:oauth:token-type:access_token'
+                requested_token_type = 'urn:ietf:params:oauth:token-type:access_token',
+                subject_token_type = 'urn:ietf:params:oauth:token-type:access_token'
             )
             data = parse.urlencode(values)
 


### PR DESCRIPTION
As of Keycloak 26.2, "Standard token exchange V2" is an officially supported feature. As part of the specification for this feature, the field `subject_token_type` is a required header in the exchange request (and must be `urn:ietf:params:oauth:token-type:access_token`): https://www.keycloak.org/securing-apps/token-exchange#_standard-token-exchange-request . If `subject_token_type` is absent, Keycloak throws an error and rejects the exchange request.

This commit adds the correct subject_token_type field to the request header to allow use of the new standard token exchange V2.