### PR TITLE
swanspawner: Redefinition of `accpy_image` for making the CI process easier

### DIFF
--- a/SwanSpawner/swanspawner/swankubespawner.py
+++ b/SwanSpawner/swanspawner/swankubespawner.py
@@ -6,7 +6,7 @@ from kubernetes_asyncio.client.rest import ApiException
 
 import os
 from math import ceil
-from traitlets import Float, Unicode
+from traitlets import Float, Unicode, Dict
 
 
 class SwanKubeSpawner(define_SwanSpawner_from(KubeSpawner)):
@@ -22,7 +22,7 @@ class SwanKubeSpawner(define_SwanSpawner_from(KubeSpawner)):
         help='URL of the CentOS7 user image.'
     )
 
-    accpy_image = Unicode(
+    accpy = Dict(
         config=True,
         help='URL of the Acc-Py user image.'
     )
@@ -58,7 +58,7 @@ class SwanKubeSpawner(define_SwanSpawner_from(KubeSpawner)):
         # If the user selected an Acc-Py based custom environment,
         # use the corresponding image.
         if self.user_options[self.software_source] == self.customenv_special_type and self.user_options[self.builder] == 'accpy':
-            image = self.accpy_image
+            image = self.accpy['image']['name'] + ':' + self.accpy['image']['tag']
             if not image:
                 raise RuntimeError('The user selected an Acc-Py environment, but no Acc-Py image was configured')
             self.image = image


### PR DESCRIPTION
With these changes, alongside with the ones in the charts (click [here](https://github.com/swan-cern/swan-charts/pull/394)), the CI used for updating the swan-cern version can be reused also for swan-accpy.