### PR TITLE
Use a raw string for a regex pattern

### DIFF
--- a/SwanSpawner/swanspawner/_gpuinfo.py
+++ b/SwanSpawner/swanspawner/_gpuinfo.py
@@ -242,7 +242,7 @@ class AvailableGPUs:
         '''
         # Look for MIG partitions in the allocatable resources list
         for resource_name,count in node_status.allocatable.items():
-            m = re.match('nvidia.com/mig-\d+g.(\d+)gb', resource_name) # e.g. nvidia.com/mig-1g.5gb
+            m = re.match(r'nvidia.com/mig-\d+g.(\d+)gb', resource_name) # e.g. nvidia.com/mig-1g.5gb
             if m and int(count) > 0:
                 memory = m.group(1)
                 description = f'{gpu_model} partition ({memory} GB)'

--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -284,7 +284,7 @@ def define_SwanSpawner_from(base_class):
                 if exit_return_code.isdigit():
                     value_cleaned = exit_return_code
                 else:
-                    result = re.search('ExitCode=(\d+)', exit_return_code)
+                    result = re.search(r'ExitCode=(\d+)', exit_return_code)
                     if not result:
                         raise Exception("unknown exit code format for this Spawner")
                     value_cleaned = result.group(1)


### PR DESCRIPTION
In recent Python versions (3.12+), `'\d'` emits a SyntaxWarning (e.g. `SyntaxWarning: invalid escape sequence '\d'`)

We can use a raw string to treat the backslash in `'\d'` as a literal backslash and get rid of the warning.