### PR TITLE
Simplify `log_metric` calls in `swanspawner.py`

### DIFF
--- a/SwanSpawner/swanspawner/swanspawner.py
+++ b/SwanSpawner/swanspawner/swanspawner.py
@@ -267,7 +267,7 @@ def define_SwanSpawner_from(base_class):
             self.log_metric(
                 self.user.name,
                 self.this_host,
-                ".".join(["exit_container_code"]),
+                "exit_container_code",
                 container_exit_code
             )
 
@@ -292,7 +292,7 @@ def define_SwanSpawner_from(base_class):
                 self.log_metric(
                     self.user.name,
                     self.this_host,
-                    ".".join(["exit_container_code"]),
+                    "exit_container_code",
                     value_cleaned
                 )
 
@@ -323,7 +323,7 @@ def define_SwanSpawner_from(base_class):
             self.log_metric(
                 self.user.name,
                 self.this_host,
-                ".".join(["start_container_duration_sec"]),
+                "start_container_duration_sec",
                 time.time() - start_time_start_container
             )
 


### PR DESCRIPTION
We're calling `join` with a single element list. This can just be replaced with a string literal.