### PR TITLE
ci: Fix env variable not being replaced in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Publish to PyPI 🚀
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
-          packages-dir: ./${EXTENSION}/dist/
+          packages-dir: ./${{ env.EXTENSION }}/dist/
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
Variable replacement is only avaiable in the "run" fields, because these fields are executed with shell (such as bash), which replaces the variable by its value automatically.

However, when using it in other GitHub Actions fields, including subfields of the "with" field, these need to have double curly braces and the "env." prefix, in order to be substituted by the interpreter.