### PR TITLE
keycloakauthenticator: Bump ruff target to 3.12 and fix lint errors

### DIFF
--- a/KeyCloakAuthenticator/keycloakauthenticator/auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/auth.py
@@ -245,7 +245,7 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
 
         # Inspect the responses obtained for each service
         access_tokens = {}
-        for response, service_name in zip(responses, self.exchange_tokens):
+        for response, service_name in zip(responses, self.exchange_tokens, strict=True):
             # Get the access token obtained for this service
             access_token = None
             if response.body:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
 ]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
We now require Python 3.12+ so we can bump the ruff target version. It only found one issue related to the zip `strict` argument.