### PR TITLE
swanculler, swanspawner: Enable more ruff rules

### DIFF
--- a/SwanCuller/swanculler/app.py
+++ b/SwanCuller/swanculler/app.py
@@ -34,7 +34,7 @@ the ``--cull-users`` option.
 """
 import json
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from functools import partial
 
 try:
@@ -72,7 +72,7 @@ def parse_date(date_string):
     dt = dateutil.parser.parse(date_string)
     if not dt.tzinfo:
         # assume naïve timestamps are UTC
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=UTC)
     return dt
 
 
@@ -126,7 +126,7 @@ def cull_idle(
     """
     auth_header = {'Authorization': 'token %s' % api_token}
     req = HTTPRequest(url=url + '/users', headers=auth_header)
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     client = AsyncHTTPClient()
 
     if concurrency:

--- a/SwanCuller/tests/test_app.py
+++ b/SwanCuller/tests/test_app.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from swanculler import app
@@ -10,7 +10,7 @@ from swanculler.app import check_blocked_users
 # ---------------------------------------------------------------------------
 
 def make_user(name):
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
     return {
         "name": name,
         "servers": {'': {

--- a/SwanSpawner/swanspawner/_gpuinfo.py
+++ b/SwanSpawner/swanspawner/_gpuinfo.py
@@ -3,7 +3,6 @@ import re
 from dataclasses import dataclass
 from threading import Lock, Thread
 from time import sleep
-from typing import Union
 
 from kubernetes import client, config
 from kubernetes.client.models import V1NodeStatus
@@ -104,7 +103,7 @@ class AvailableGPUs:
         except Exception as e:
             self._logger.exception(f'Unexpected error during currently free GPU check: {e}')
 
-    def get_info(self, description: str) -> Union[_GPUInfo, None]:
+    def get_info(self, description: str) -> _GPUInfo | None:
         return self._gpus.get(description, None)
 
     def _role_flags(self, roles: list[str]) -> tuple[bool, bool, bool]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ select = [
     "SIM118",  # in-dict-keys
     "UP007",   # PEP 604 union
     "UP015",   # redundant-open-modes
+    "UP017",   # datetime.UTC
     "UP032",   # f-string
     "W",       # pycodestyle warnings
     "YTT",     # flake8-2020

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ select = [
     "RET502",  # implicit-return-value
     "RUF",     # Ruff-specific
     "SIM118",  # in-dict-keys
+    "UP007",   # PEP 604 union
     "UP015",   # redundant-open-modes
     "UP032",   # f-string
     "W",       # pycodestyle warnings


### PR DESCRIPTION
Enabled two more auto-fixable pyupgrade rules which are now available thanks to requiring Python 3.12+