### PR TITLE
swanhub: Sentry: Decrease traces sample rate

### DIFF
--- a/SwanHub/swanhub/app.py
+++ b/SwanHub/swanhub/app.py
@@ -57,7 +57,7 @@ class SWAN(app.JupyterHub):
             # SENTRY_DSN and SENTRY_ENVIRONMENT are read from environment variables
             send_default_pii=True,
             attach_stacktrace=True,
-            traces_sample_rate=0.1,
+            traces_sample_rate=0.01,
             in_app_include=[
                 "keycloakauthenticator",
                 "swanculler",


### PR DESCRIPTION
The rate is apparently too high given the limit of the CERN Sentry instance. Since traces are mainly for measuring performance, we don't really need a high rate anyway - we already collect performance metrics outside Sentry.