### PR TITLE
ci: Ignore ASYNC240

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ select = [
 ignore = [
     "ASYNC221", # run-process-in-async-function
     "ASYNC230", # blocking-open-call-in-async-function
+    "ASYNC240", # blocking-path-method-in-async-function
     "B006",     # mutable-argument-default
     "B007",     # unused-loop-control-variable
     "B904",     # raise-without-from-inside-except


### PR DESCRIPTION
This was added in the latest version of ruff. It produces a few hits so let's just ignore it for now.