### PR TITLE
swanhub: Remove lesshat

### DIFF
--- a/SwanHub/package-lock.json
+++ b/SwanHub/package-lock.json
@@ -10,8 +10,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "less": "3.9.0",
-        "less-plugin-clean-css": "^1.5.1",
-        "lesshat": "^4.1.0"
+        "less-plugin-clean-css": "^1.5.1"
       }
     },
     "node_modules/ajv": {
@@ -451,12 +450,6 @@
       "engines": {
         "node": ">=0.4.2"
       }
-    },
-    "node_modules/lesshat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lesshat/-/lesshat-4.1.0.tgz",
-      "integrity": "sha1-WjLco2pVFlaaSG+O0Q3//3nUyOA= sha512-TrBB7GgAUwK5S1KZw5arpyqwkqUhx62QjZDn9LujUHX7eDkx9ofOorawhGP2yWRbgB0EIILGf8uWW4BHu8MNOA==",
-      "dev": true
     },
     "node_modules/mime": {
       "version": "1.6.0",

--- a/SwanHub/package.json
+++ b/SwanHub/package.json
@@ -11,7 +11,6 @@
   },
   "devDependencies": {
     "less": "3.9.0",
-    "less-plugin-clean-css": "^1.5.1",
-    "lesshat": "^4.1.0"
+    "less-plugin-clean-css": "^1.5.1"
   }
 }

--- a/SwanHub/swanhub/static/css/style.less
+++ b/SwanHub/swanhub/static/css/style.less
@@ -1,4 +1,3 @@
-@import "lesshat/lesshat";
 @import "vars";
 @import url("icons.css");
 

--- a/SwanHub/swanhub/static/css/style_legacy.less
+++ b/SwanHub/swanhub/static/css/style_legacy.less
@@ -1,4 +1,3 @@
-@import "lesshat/lesshat";
 @import "vars";
 @import url("icons.css");
 
@@ -157,14 +156,14 @@ header {
                     i {
                         margin-right: 10px;
                         opacity: 0;
-                        .transition(all .5s);
+                        transition: all .5s;
                         position: absolute;
                         left: 12px;
                         padding-top: 5px;
                     }
 
                     .text {
-                        .transition(all .5s);
+                        transition: all .5s;
                         position: relative;
                         left: 0;
                         font-size: @menu-font-size;
@@ -495,7 +494,7 @@ ul#options-menu {
         }
 
         .actions {
-            .transition(all .2s);
+            transition: all .2s;
             opacity: 0;
             margin: 0;
             padding: 0;
@@ -747,7 +746,7 @@ ul#options-menu {
 
             .modal-dialog {
                 right: -450px;
-                .transition(opacity 0.2s linear, right 0.2s ease-out, width 0.3s ease-in-out);
+                transition: opacity 0.2s linear, right 0.2s ease-out, width 0.3s ease-in-out;
             }
 
             &.in .modal-dialog {
@@ -879,7 +878,7 @@ ul#options-menu {
 
     #menubar-container {
         background-color: @grey-2;
-        .transition(top 0.2s ease-in-out);
+        transition: top 0.2s ease-in-out;
 
         #menus {
             background-color: transparent;
@@ -1024,7 +1023,7 @@ span.save_widget {
 
     .taking-long {
         opacity: 0;
-        .transition(opacity 0.1s linear, right 0.1s ease-out);
+        transition: opacity 0.1s linear, right 0.1s ease-out;
     }
 }
 
@@ -1034,7 +1033,8 @@ span.save_widget {
         position: absolute;
         left: 50%;
         top: 40%;
-        .size(@loader-size);
+        width: @loader-size;
+        height: @loader-size;
         margin-left: -@loader-size/2;
         margin-top: -@loader-size/2;
 
@@ -1052,18 +1052,20 @@ span.save_widget {
         position: absolute;
         left: 50%;
         top: 40%;
-        .size(@loader-size, 350);
+        width: @loader-size;
+        height: 350px;
         margin-left: -@loader-size/2;
         margin-top: -@loader-size/2;
         overflow: hidden;
-        .transform-origin(@loader-size/2 @loader-size/2);
+        transform-origin: @loader-size/2 @loader-size/2;
         -webkit-mask-image: -webkit-linear-gradient(top, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
         mask-image: linear-gradient(top, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
         mask: url(loading_clip.svg#loading-mask);
-        .animation(rotate 1.2s infinite linear);
+        animation: rotate 1.2s infinite linear;
 
         .loader-line {
-            .size(@loader-size);
+            width: @loader-size;
+            height: @loader-size;
             border-radius: 50%;
             box-shadow: inset 0 0 0 9px rgba(red(@color-secondary), green(@color-secondary), blue(@color-secondary), 1);
         }
@@ -1073,7 +1075,8 @@ span.save_widget {
         position: absolute;
         left: 50%;
         top: 40%;
-        .size(@loader-size+20px, 3em);
+        width: @loader-size+20px;
+        height: 3em;
         font-size: 2em;
         vertical-align: middle;
         line-height: 3em;
@@ -1092,11 +1095,20 @@ span.save_widget {
     }
 }
 
-.keyframes(~'rotate, 0% { transform: rotate(0deg);} 100% { transform: rotate(360deg);}');
+@keyframes rotate {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
 
-.keyframes(~'fade, 0% { opacity: 1;} 50% { opacity: 0.25;}');
+@keyframes fade {
+    0% { opacity: 1; }
+    50% { opacity: 0.25; }
+}
 
-.keyframes(~'fade-in, 0% { opacity: 0;} 100% { opacity: 1;}');
+@keyframes fade-in {
+    0% { opacity: 0; }
+    100% { opacity: 1; }
+}
 
 #help-modal {
 
@@ -1993,7 +2005,7 @@ span.save_widget {
                 margin: @article-padding;
                 padding: 0;
                 border: solid 1px @grey-2;
-                .transition(all .2s ease-in-out);
+                transition: all .2s ease-in-out;
             }
 
             a, a:hover, a:active, a:visited {
@@ -2012,7 +2024,7 @@ span.save_widget {
                 left: @article-padding;
                 overflow: hidden;
                 line-height: 20px;
-                .transition(all .2s ease-in-out);
+                transition: all .2s ease-in-out;
             }
 
             .background {
@@ -2024,7 +2036,7 @@ span.save_widget {
                 right: 0;
                 bottom: 0;
                 z-index: -1;
-                .transition(opacity .2s ease-in-out);
+                transition: opacity .2s ease-in-out;
             }
 
             &:hover {


### PR DESCRIPTION
This package was last published [10(!) years ago](https://www.npmjs.com/package/lesshat#size). Given that we only use it in the legacy styles (which are themselves mostly unused), let's remove it.