### PR TITLE
swanhub: Add `Service Status` button

### DIFF
--- a/SwanHub/swanhub/templates/page.html
+++ b/SwanHub/swanhub/templates/page.html
@@ -97,6 +97,10 @@
        class="text-decoration-none link-secondary small">
       <i class="fa fa-home me-1"></i>Home
     </a>
+    <a href="https://monit-grafana.cern.ch/d/afo7vryd75zwge/swan-service-status?orgId=53&refresh=auto&from=now-24h&to=now"
+       class="text-decoration-none link-secondary small">
+      <i class="fa fa-heart-pulse me-1"></i>Service Status
+    </a>
     <a href="https://swan-community.web.cern.ch/"
        class="text-decoration-none link-secondary small">
       <i class="fa fa-users me-1"></i>Community


### PR DESCRIPTION
This button leads the user to a Grafana Dashboard with useful information for the user to check the SWAN Status