### PR TITLE
KeyCloakAuthenticator:implement tests for _get_oidc_configs function

### DIFF
--- a/KeyCloakAuthenticator/keycloakauthenticator/auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/auth.py
@@ -156,48 +156,51 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
         asyncio.ensure_future(self._get_oidc_configs())
         self.login_handler = OIDCOAuthLoginHandler
 
-    async def _get_oidc_configs(self):
 
+    async def _get_oidc_configs_helper(self):
+        data = await self.httpfetch(f"{self.oidc_issuer}/.well-known/openid-configuration", label="fetching oidc config")
+
+        if not set(['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint']).issubset(data.keys()):
+            raise Exception('Unable to retrieve OIDC necessary values')
+
+        self.authorize_url = data['authorization_endpoint']
+        self.token_url = data['token_endpoint']
+        self.userdata_url = data['userinfo_endpoint']
+
+        end_session_url = data.get('end_session_endpoint')
+        if self.enable_logout and end_session_url:
+            if self.logout_redirect_url:
+                end_session_url += '?post_logout_redirect_uri=%s' % self.logout_redirect_url
+                end_session_url += '&client_id=%s' % self.client_id
+            # Update parent class OAuthenticator.logout_redirect_url
+            self.logout_redirect_url = end_session_url
+
+        if self.config.check_signature :
+            jwks_uri = data['jwks_uri']
+
+            self.log.info("Fetching JWKs data")
+            jwk_data = await self.httpfetch(jwks_uri, label="fetching jwks")
+            # Find signature key out of keys provided at certs endpoint
+            sign_keys = [key for key in jwk_data['keys'] if key.get('use') == 'sig']
+            if not sign_keys:
+                # If no signature key is found, fallback to first key in the list
+                sign_keys = jwk_data['keys']
+            self.public_key = RSAAlgorithm(RSAAlgorithm.SHA256).from_jwk(sign_keys[0])
+            self.log.info(f"acquired public key from {jwks_uri}")
+        else:
+            self.public_key = None
+
+        self.configured = True
+        # All good, let's finish
+        self.log.info('KeycloakAuthenticator fully configured')
+
+    async def _get_oidc_configs(self):
         self.log.info('Configuring OIDC from %s' % self.oidc_issuer)
 
         # Try to load the configs until it succeeds
         while True:
             try:
-                data = await self.httpfetch(f"{self.oidc_issuer}/.well-known/openid-configuration", label="fetching oidc config")
-
-                if not set(['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint']).issubset(data.keys()):
-                    raise Exception('Unable to retrieve OIDC necessary values')
-
-                self.authorize_url = data['authorization_endpoint']
-                self.token_url = data['token_endpoint']
-                self.userdata_url = data['userinfo_endpoint']
-
-                end_session_url = data.get('end_session_endpoint')
-                if self.enable_logout and end_session_url:
-                    if self.logout_redirect_url:
-                        end_session_url += '?post_logout_redirect_uri=%s' % self.logout_redirect_url
-                        end_session_url += '&client_id=%s' % self.client_id
-                    # Update parent class OAuthenticator.logout_redirect_url
-                    self.logout_redirect_url = end_session_url
-
-                if self.config.check_signature :
-                    jwks_uri = data['jwks_uri']
-
-                    self.log.info("Fetching JWKs data")
-                    jwk_data = await self.httpfetch(jwks_uri, label="fetching jwks")
-                    # Find signature key out of keys provided at certs endpoint
-                    sign_keys = [key for key in jwk_data['keys'] if key.get('use') == 'sig']
-                    if not sign_keys:
-                        # If no signature key is found, fallback to first key in the list
-                        sign_keys = jwk_data['keys']
-                    self.public_key = RSAAlgorithm(RSAAlgorithm.SHA256).from_jwk(sign_keys[0])
-                    self.log.info(f"acquired public key from {jwks_uri}")
-                else:
-                    self.public_key = None
-
-                self.configured = True
-                # All good, let's finish
-                self.log.info('KeycloakAuthenticator fully configured')
+                await self._get_oidc_configs_helper()
                 break
             except Exception:
                 self.log.error("Failure to retrieve the openid configuration, will try again in 1 min (auth calls will fail)", exc_info=True)

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -229,6 +229,23 @@ class TestGetOidcConfigs:
 
         assert unconfigured_authenticator.public_key is not None
 
+    
+    @pytest.mark.asyncio
+    async def test_check_signature_false_skip_jwks_fetch(self, unconfigured_authenticator, monkeypatch):
+        call_count = 0
+
+        async def mock_httpfetch(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return OIDC_DISCOVERY_DOC
+
+        monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
+
+        await unconfigured_authenticator._get_oidc_configs()
+
+        assert call_count == 1
+        assert unconfigured_authenticator.public_key is None
+
 
 
 @pytest.mark.asyncio

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -1,4 +1,5 @@
 import json
+import asyncio
 
 import jwt
 import pytest
@@ -31,6 +32,68 @@ def _get_mock_token(private_key, token_id, expired=False):
         algorithm="RS256",
         headers={"kid": "dummy-key-id"},
     )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def unconfigured_authenticator(monkeypatch):
+    monkeypatch.setattr(asyncio, "ensure_future", lambda coro: coro.close())
+    async def _break_retry_loop(_):
+        raise RuntimeError("asyncio.sleep called unexpectedly — check for uncaught exceptions in _get_oidc_configs")
+    monkeypatch.setattr(asyncio, "sleep", _break_retry_loop)
+    auth = KeyCloakAuthenticator(oidc_issuer="http://fake-issuer")
+    auth.config.check_signature = False  # disabled by default; check_signature tests enable it explicitly
+    return auth
+
+
+# ---------------------------------------------------------------------------
+# TestGetOidcConfigs
+# ---------------------------------------------------------------------------
+
+class TestGetOidcConfigs:
+    """
+    options are:
+     - authorize_url, token_url, userdata_url not all present, expect exception and have to break loop by patching sleep [test_missing_required_authorisation_fields]
+
+     - authorize_url, token_url, userdata_url all present, 
+        - enable_logout and end_session present
+            - logout_redirect_url not present
+            - logout_redirect_url present
+
+        - enable_logout and end_session not all present
+
+        - check_signature True
+            - sign_keys True
+            - sign_keys False
+        - check_signature False
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("doc", [
+        {},
+        {"authorization_endpoint": "http://fake/auth"},
+        {"authorization_endpoint": "http://fake/auth", "token_endpoint": "http://fake/token"},
+        {"token_endpoint": "http://fake/token"},
+    ])
+    async def test_missing_required_authorisation_fields(self, unconfigured_authenticator, monkeypatch, doc):
+        async def mock_httpfetch(url, **kwargs):
+            return doc
+
+        async def mock_sleep(_):
+            raise RuntimeError("breaking retry loop")
+
+        monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
+        monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+
+        with pytest.raises(RuntimeError):
+            await unconfigured_authenticator._get_oidc_configs()
+
+        assert unconfigured_authenticator.configured is False
+
+
 
 @pytest.mark.asyncio
 async def test_refresh_user(monkeypatch):

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -153,6 +153,23 @@ class TestGetOidcConfigs:
             "&client_id=dummy-client"
         )
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("enable_logout,doc", [
+        (False, {**OIDC_DISCOVERY_DOC, "end_session_endpoint": "http://fake/logout"}),
+        (True, OIDC_DISCOVERY_DOC),
+    ])
+    async def test_logout_url_not_updated(self, unconfigured_authenticator, monkeypatch, enable_logout, doc):
+        unconfigured_authenticator.enable_logout = enable_logout
+        original_logout_url = unconfigured_authenticator.logout_redirect_url
+
+        async def mock_httpfetch(url, **kwargs):
+            return doc
+
+        monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
+
+        await unconfigured_authenticator._get_oidc_configs()
+
+        assert unconfigured_authenticator.logout_redirect_url == original_logout_url
 
 @pytest.mark.asyncio
 async def test_refresh_user(monkeypatch):

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -92,7 +92,7 @@ class TestGetOidcConfigs:
         - check_signature False
     """
 
-    @pytest.mark.asyncio
+
     @pytest.mark.parametrize("doc", [
         {},
         {"authorization_endpoint": "http://fake/auth"},
@@ -111,7 +111,7 @@ class TestGetOidcConfigs:
         assert unconfigured_authenticator.configured is False
 
 
-    @pytest.mark.asyncio
+
     async def test_set_urls(self, unconfigured_authenticator, monkeypatch):
         async def mock_httpfetch(url, **kwargs):
             return OIDC_DISCOVERY_DOC
@@ -126,7 +126,7 @@ class TestGetOidcConfigs:
         assert unconfigured_authenticator.configured is True
 
 
-    @pytest.mark.asyncio
+
     async def test_enable_logout_end_session_no_existing_redirect_url(self, unconfigured_authenticator, monkeypatch):
         unconfigured_authenticator.enable_logout = True
         unconfigured_authenticator.logout_redirect_url = ""
@@ -140,7 +140,7 @@ class TestGetOidcConfigs:
 
         assert unconfigured_authenticator.logout_redirect_url == "http://fake/logout"
 
-    @pytest.mark.asyncio
+
     async def test_enable_logout_end_session_existing_redirect_url(self, unconfigured_authenticator, monkeypatch):
         unconfigured_authenticator.enable_logout = True
         unconfigured_authenticator.logout_redirect_url = "http://fake/post-logout"
@@ -159,7 +159,7 @@ class TestGetOidcConfigs:
             "&client_id=dummy-client"
         )
 
-    @pytest.mark.asyncio
+
     @pytest.mark.parametrize("enable_logout,doc", [
         (False, {**OIDC_DISCOVERY_DOC, "end_session_endpoint": "http://fake/logout"}),
         (True, OIDC_DISCOVERY_DOC),
@@ -178,7 +178,7 @@ class TestGetOidcConfigs:
         assert unconfigured_authenticator.logout_redirect_url == original_logout_url
 
 
-    @pytest.mark.asyncio
+
     async def test_check_signature_true_sig_key_present(self, unconfigured_authenticator, monkeypatch, key_pair):
         public_key, _ = key_pair
         jwks = _make_jwks(public_key, use_sig=True)
@@ -201,7 +201,7 @@ class TestGetOidcConfigs:
         assert call_count == 2
 
 
-    @pytest.mark.asyncio
+
     async def test_check_signature_true_no_sig_key(self, unconfigured_authenticator, monkeypatch, key_pair):
         public_key, _ = key_pair
         jwks = _make_jwks(public_key, use_sig=False)
@@ -223,7 +223,7 @@ class TestGetOidcConfigs:
         assert unconfigured_authenticator.public_key is not None
 
     
-    @pytest.mark.asyncio
+
     async def test_check_signature_false_skip_jwks_fetch(self, unconfigured_authenticator, monkeypatch):
         call_count = 0
 
@@ -240,7 +240,7 @@ class TestGetOidcConfigs:
         assert unconfigured_authenticator.public_key is None
 
     
-    @pytest.mark.asyncio
+
     async def test_retries_after_failure(self, unconfigured_authenticator, monkeypatch):
         call_count = 0
 
@@ -267,7 +267,6 @@ class TestGetOidcConfigs:
     
 
 
-@pytest.mark.asyncio
 async def test_refresh_user(monkeypatch):
     """
     Test KeyCloakAuthenticator.refresh_user() when everything works fine.
@@ -336,7 +335,6 @@ async def test_refresh_user(monkeypatch):
     )
 
 
-@pytest.mark.asyncio
 async def test_refresh_user_with_expired_refresh_token(monkeypatch):
     """
     Test KeyCloakAuthenticator.refresh_user() when the refresh_token stored in the users auth_state

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -208,6 +208,29 @@ class TestGetOidcConfigs:
         assert call_count == 2
 
 
+    @pytest.mark.asyncio
+    async def test_check_signature_true_no_sig_key(self, unconfigured_authenticator, monkeypatch, key_pair):
+        public_key, _ = key_pair
+        jwks = _make_jwks(public_key, use_sig=False)
+
+        call_count = 0
+
+        async def mock_httpfetch(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {**OIDC_DISCOVERY_DOC, "jwks_uri": "http://fake/certs"}
+            return jwks
+
+        monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
+        unconfigured_authenticator.config.check_signature = True
+
+        await unconfigured_authenticator._get_oidc_configs()
+
+        assert unconfigured_authenticator.public_key is not None
+
+
+
 @pytest.mark.asyncio
 async def test_refresh_user(monkeypatch):
     """

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -50,6 +50,17 @@ def unconfigured_authenticator(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+OIDC_DISCOVERY_DOC = {
+    "authorization_endpoint": "http://fake/auth",
+    "token_endpoint": "http://fake/token",
+    "userinfo_endpoint": "http://fake/userinfo",
+}
+
+
+# ---------------------------------------------------------------------------
 # TestGetOidcConfigs
 # ---------------------------------------------------------------------------
 
@@ -92,6 +103,22 @@ class TestGetOidcConfigs:
             await unconfigured_authenticator._get_oidc_configs()
 
         assert unconfigured_authenticator.configured is False
+
+
+    @pytest.mark.asyncio
+    async def test_set_urls(self, unconfigured_authenticator, monkeypatch):
+        async def mock_httpfetch(url, **kwargs):
+            return OIDC_DISCOVERY_DOC
+
+        monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
+
+        await unconfigured_authenticator._get_oidc_configs()
+
+        assert unconfigured_authenticator.authorize_url == "http://fake/auth"
+        assert unconfigured_authenticator.token_url == "http://fake/token"
+        assert unconfigured_authenticator.userdata_url == "http://fake/userinfo"
+        assert unconfigured_authenticator.configured is True
+
 
 
 

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -335,31 +335,6 @@ async def test_refresh_user(monkeypatch):
     )
 
 
-@pytest.fixture
-def authenticator(unconfigured_authenticator):
-    unconfigured_authenticator.token_url = "http://fake/token"
-    unconfigured_authenticator.client_id = "dummy-client"
-    unconfigured_authenticator.client_secret = "dummy-secret"
-    unconfigured_authenticator.configured = True
-    return unconfigured_authenticator
-
-
-class TestRefreshToken:
-    """
-    options are:
-    - response.body True
-        - access_token is None
-        - access_token non None
-        - refresh_token is None
-        - refresh_token non None
-        - both are None
-
-    - response.body False
-
-    """
-
-    def test_response_body_empty(self, authenticator):
-        pass
 
 
 async def test_refresh_user_with_expired_refresh_token(monkeypatch):

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -239,7 +239,7 @@ class TestGetOidcConfigs:
         assert call_count == 1
         assert unconfigured_authenticator.public_key is None
 
-    """
+    
     @pytest.mark.asyncio
     async def test_retries_after_failure(self, unconfigured_authenticator, monkeypatch):
         call_count = 0
@@ -264,7 +264,7 @@ class TestGetOidcConfigs:
         assert call_count == 2
         assert len(sleep_calls) == 1
         assert sleep_calls[0] == 60
-    """
+    
 
 
 @pytest.mark.asyncio

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -120,6 +120,38 @@ class TestGetOidcConfigs:
         assert unconfigured_authenticator.configured is True
 
 
+    @pytest.mark.asyncio
+    async def test_enable_logout_end_session_no_existing_redirect_url(self, unconfigured_authenticator, monkeypatch):
+        unconfigured_authenticator.enable_logout = True
+        unconfigured_authenticator.logout_redirect_url = ""
+
+        async def mock_httpfetch(url, **kwargs):
+            return {**OIDC_DISCOVERY_DOC, "end_session_endpoint": "http://fake/logout"}
+
+        monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
+
+        await unconfigured_authenticator._get_oidc_configs()
+
+        assert unconfigured_authenticator.logout_redirect_url == "http://fake/logout"
+
+    @pytest.mark.asyncio
+    async def test_enable_logout_end_session_existing_redirect_url(self, unconfigured_authenticator, monkeypatch):
+        unconfigured_authenticator.enable_logout = True
+        unconfigured_authenticator.logout_redirect_url = "http://fake/post-logout"
+        unconfigured_authenticator.client_id = "dummy-client"
+
+        async def mock_httpfetch(url, **kwargs):
+            return {**OIDC_DISCOVERY_DOC, "end_session_endpoint": "http://fake/logout"}
+
+        monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
+
+        await unconfigured_authenticator._get_oidc_configs()
+
+        assert unconfigured_authenticator.logout_redirect_url == (
+            "http://fake/logout"
+            "?post_logout_redirect_uri=http://fake/post-logout"
+            "&client_id=dummy-client"
+        )
 
 
 @pytest.mark.asyncio

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -42,9 +42,6 @@ def _get_mock_token(private_key, token_id, expired=False):
 @pytest.fixture
 def unconfigured_authenticator(monkeypatch):
     monkeypatch.setattr(asyncio, "ensure_future", lambda coro: coro.close())
-    async def _break_retry_loop(_):
-        raise RuntimeError("asyncio.sleep called unexpectedly — check for uncaught exceptions in _get_oidc_configs")
-    monkeypatch.setattr(asyncio, "sleep", _break_retry_loop)
     auth = KeyCloakAuthenticator(oidc_issuer="http://fake-issuer")
     auth.config.check_signature = False  # disabled by default; check_signature tests enable it explicitly
     return auth
@@ -106,14 +103,10 @@ class TestGetOidcConfigs:
         async def mock_httpfetch(url, **kwargs):
             return doc
 
-        async def mock_sleep(_):
-            raise RuntimeError("breaking retry loop")
-
         monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
-        monkeypatch.setattr(asyncio, "sleep", mock_sleep)
 
-        with pytest.raises(RuntimeError):
-            await unconfigured_authenticator._get_oidc_configs()
+        with pytest.raises(Exception, match = "Unable to retrieve OIDC necessary values"):
+            await unconfigured_authenticator._get_oidc_configs_helper()
 
         assert unconfigured_authenticator.configured is False
 
@@ -125,7 +118,7 @@ class TestGetOidcConfigs:
 
         monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
 
-        await unconfigured_authenticator._get_oidc_configs()
+        await unconfigured_authenticator._get_oidc_configs_helper()
 
         assert unconfigured_authenticator.authorize_url == "http://fake/auth"
         assert unconfigured_authenticator.token_url == "http://fake/token"
@@ -143,7 +136,7 @@ class TestGetOidcConfigs:
 
         monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
 
-        await unconfigured_authenticator._get_oidc_configs()
+        await unconfigured_authenticator._get_oidc_configs_helper()
 
         assert unconfigured_authenticator.logout_redirect_url == "http://fake/logout"
 
@@ -158,7 +151,7 @@ class TestGetOidcConfigs:
 
         monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
 
-        await unconfigured_authenticator._get_oidc_configs()
+        await unconfigured_authenticator._get_oidc_configs_helper()
 
         assert unconfigured_authenticator.logout_redirect_url == (
             "http://fake/logout"
@@ -180,7 +173,7 @@ class TestGetOidcConfigs:
 
         monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
 
-        await unconfigured_authenticator._get_oidc_configs()
+        await unconfigured_authenticator._get_oidc_configs_helper()
 
         assert unconfigured_authenticator.logout_redirect_url == original_logout_url
 
@@ -202,7 +195,7 @@ class TestGetOidcConfigs:
         monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
         unconfigured_authenticator.config.check_signature = True
 
-        await unconfigured_authenticator._get_oidc_configs()
+        await unconfigured_authenticator._get_oidc_configs_helper()
 
         assert unconfigured_authenticator.public_key is not None
         assert call_count == 2
@@ -225,7 +218,7 @@ class TestGetOidcConfigs:
         monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
         unconfigured_authenticator.config.check_signature = True
 
-        await unconfigured_authenticator._get_oidc_configs()
+        await unconfigured_authenticator._get_oidc_configs_helper()
 
         assert unconfigured_authenticator.public_key is not None
 
@@ -241,7 +234,7 @@ class TestGetOidcConfigs:
 
         monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
 
-        await unconfigured_authenticator._get_oidc_configs()
+        await unconfigured_authenticator._get_oidc_configs_helper()
 
         assert call_count == 1
         assert unconfigured_authenticator.public_key is None

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -239,6 +239,32 @@ class TestGetOidcConfigs:
         assert call_count == 1
         assert unconfigured_authenticator.public_key is None
 
+    """
+    @pytest.mark.asyncio
+    async def test_retries_after_failure(self, unconfigured_authenticator, monkeypatch):
+        call_count = 0
+
+        async def mock_helper(self):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("transient failure")
+            unconfigured_authenticator.configured = True
+
+        sleep_calls = []
+
+        async def mock_sleep(duration):
+            sleep_calls.append(duration)
+
+        monkeypatch.setattr(KeyCloakAuthenticator, "_get_oidc_configs_helper", mock_helper)
+        monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+
+        await unconfigured_authenticator._get_oidc_configs()
+
+        assert call_count == 2
+        assert len(sleep_calls) == 1
+        assert sleep_calls[0] == 60
+    """
 
 
 @pytest.mark.asyncio

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -2,6 +2,7 @@ import json
 import asyncio
 
 import jwt
+from jwt.algorithms import RSAAlgorithm
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 
@@ -49,6 +50,12 @@ def unconfigured_authenticator(monkeypatch):
     return auth
 
 
+@pytest.fixture
+def key_pair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key.public_key(), private_key
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -59,6 +66,12 @@ OIDC_DISCOVERY_DOC = {
     "userinfo_endpoint": "http://fake/userinfo",
 }
 
+
+def _make_jwks(public_key, use_sig=True):
+    jwk = json.loads(RSAAlgorithm.to_jwk(public_key))
+    if use_sig:
+        jwk["use"] = "sig"
+    return {"keys": [jwk]}
 
 # ---------------------------------------------------------------------------
 # TestGetOidcConfigs
@@ -170,6 +183,30 @@ class TestGetOidcConfigs:
         await unconfigured_authenticator._get_oidc_configs()
 
         assert unconfigured_authenticator.logout_redirect_url == original_logout_url
+
+
+    @pytest.mark.asyncio
+    async def test_check_signature_true_sig_key_present(self, unconfigured_authenticator, monkeypatch, key_pair):
+        public_key, _ = key_pair
+        jwks = _make_jwks(public_key, use_sig=True)
+
+        call_count = 0
+
+        async def mock_httpfetch(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {**OIDC_DISCOVERY_DOC, "jwks_uri": "http://fake/certs"}
+            return jwks
+
+        monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
+        unconfigured_authenticator.config.check_signature = True
+
+        await unconfigured_authenticator._get_oidc_configs()
+
+        assert unconfigured_authenticator.public_key is not None
+        assert call_count == 2
+
 
 @pytest.mark.asyncio
 async def test_refresh_user(monkeypatch):

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -72,24 +72,6 @@ def _make_jwks(public_key, *, use_sig=True):
 
 
 class TestGetOidcConfigs:
-    """
-    options are:
-     - authorize_url, token_url, userdata_url not all present, expect exception and have to break loop by patching sleep [test_missing_required_authorisation_fields]
-
-     - authorize_url, token_url, userdata_url all present, 
-        - enable_logout and end_session present
-            - logout_redirect_url not present
-            - logout_redirect_url present
-
-        - enable_logout and end_session not all present
-
-        - check_signature True
-            - sign_keys True
-            - sign_keys False
-        - check_signature False
-    """
-
-
     @pytest.mark.parametrize("doc", [
         {},
         {"authorization_endpoint": "http://fake/auth"},

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -64,15 +64,12 @@ OIDC_DISCOVERY_DOC = {
 }
 
 
-def _make_jwks(public_key, use_sig=True):
+def _make_jwks(public_key, *, use_sig=True):
     jwk = json.loads(RSAAlgorithm.to_jwk(public_key))
     if use_sig:
         jwk["use"] = "sig"
     return {"keys": [jwk]}
 
-# ---------------------------------------------------------------------------
-# TestGetOidcConfigs
-# ---------------------------------------------------------------------------
 
 class TestGetOidcConfigs:
     """
@@ -105,10 +102,10 @@ class TestGetOidcConfigs:
 
         monkeypatch.setattr(unconfigured_authenticator, "httpfetch", mock_httpfetch)
 
-        with pytest.raises(Exception, match = "Unable to retrieve OIDC necessary values"):
+        with pytest.raises(Exception, match="Unable to retrieve OIDC necessary values"):
             await unconfigured_authenticator._get_oidc_configs_helper()
 
-        assert unconfigured_authenticator.configured is False
+        assert not unconfigured_authenticator.configured
 
 
 
@@ -123,7 +120,7 @@ class TestGetOidcConfigs:
         assert unconfigured_authenticator.authorize_url == "http://fake/auth"
         assert unconfigured_authenticator.token_url == "http://fake/token"
         assert unconfigured_authenticator.userdata_url == "http://fake/userinfo"
-        assert unconfigured_authenticator.configured is True
+        assert unconfigured_authenticator.configured
 
 
 

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -1,10 +1,10 @@
-import json
 import asyncio
+import json
 
 import jwt
-from jwt.algorithms import RSAAlgorithm
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
 
 from ..auth import KeyCloakAuthenticator
 
@@ -222,7 +222,7 @@ class TestGetOidcConfigs:
 
         assert unconfigured_authenticator.public_key is not None
 
-    
+
 
     async def test_check_signature_false_skip_jwks_fetch(self, unconfigured_authenticator, monkeypatch):
         call_count = 0
@@ -239,7 +239,7 @@ class TestGetOidcConfigs:
         assert call_count == 1
         assert unconfigured_authenticator.public_key is None
 
-    
+
 
     async def test_retries_after_failure(self, unconfigured_authenticator, monkeypatch):
         call_count = 0
@@ -264,7 +264,7 @@ class TestGetOidcConfigs:
         assert call_count == 2
         assert len(sleep_calls) == 1
         assert sleep_calls[0] == 60
-    
+
 
 
 async def test_refresh_user(monkeypatch):
@@ -333,6 +333,33 @@ async def test_refresh_user(monkeypatch):
     assert updated_auth_state["auth_state"]["access_token"] == _get_mock_token(
         private_key, "new_access_token"
     )
+
+
+@pytest.fixture
+def authenticator(unconfigured_authenticator):
+    unconfigured_authenticator.token_url = "http://fake/token"
+    unconfigured_authenticator.client_id = "dummy-client"
+    unconfigured_authenticator.client_secret = "dummy-secret"
+    unconfigured_authenticator.configured = True
+    return unconfigured_authenticator
+
+
+class TestRefreshToken:
+    """
+    options are:
+    - response.body True
+        - access_token is None
+        - access_token non None
+        - refresh_token is None
+        - refresh_token non None
+        - both are None
+
+    - response.body False
+
+    """
+
+    def test_response_body_empty(self, authenticator):
+        pass
 
 
 async def test_refresh_user_with_expired_refresh_token(monkeypatch):

--- a/KeyCloakAuthenticator/pyproject.toml
+++ b/KeyCloakAuthenticator/pyproject.toml
@@ -34,3 +34,6 @@ version = { path = "keycloakauthenticator/_version.py" }
 packages = ["keycloakauthenticator"]
 # tests not needed in the built package
 exclude = ["tests/"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ dev = [
     "watchfiles==1.2.0",
     "keycloakauthenticator @ file:///${PROJECT_ROOT}/KeyCloakAuthenticator",
     "swanculler @ file:///${PROJECT_ROOT}/SwanCuller",
-    "swanhub @ file:///${PROJECT_ROOT}/SwanHub",
     "swanspawner @ file:///${PROJECT_ROOT}/SwanSpawner",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dev = [
     "watchfiles==1.2.0",
     "keycloakauthenticator @ file:///${PROJECT_ROOT}/KeyCloakAuthenticator",
     "swanculler @ file:///${PROJECT_ROOT}/SwanCuller",
+    "swanhub @ file:///${PROJECT_ROOT}/SwanHub",
     "swanspawner @ file:///${PROJECT_ROOT}/SwanSpawner",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,11 @@ dev = [
     "watchfiles==1.2.0",
     "keycloakauthenticator @ file:///${PROJECT_ROOT}/KeyCloakAuthenticator",
     "swanculler @ file:///${PROJECT_ROOT}/SwanCuller",
-    "swanhub @ file:///${PROJECT_ROOT}/SwanHub",
     "swanspawner @ file:///${PROJECT_ROOT}/SwanSpawner",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
includes tests for all branches in the _get_oidc_configs function, implements the unconfigured_authenticator monkeypatch to break out of loop and replace sleep.

branch options are:
- authorize_url, token_url, userdata_url not all present, expect exception and have to break loop by patching sleep                                                
 [test_missing_required_authorisation_fields]

- authorize_url, token_url, userdata_url all present, 
  - enable_logout and end_session present [test_set_urls]
      - logout_redirect_url not present [test_enable_logout_end_session_no_existing_redirect_url]
      - logout_redirect_url present [test_enable_logout_end_session_existing_redirect_url]
  - enable_logout and end_session not all present [test_logout_url_not_updated]
  
- check_signature True
    - sign_keys True [test_check_signature_true_sig_key_present]
    - sign_keys False [test_check_signature_true_no_sig_key]
   
 - check_signature False [test_check_signature_false_skip_jwks_fetch]