### PR TITLE
KeyCloakAuthenticator: Stop using preferred_username to identify users

### DIFF
--- a/KeyCloakAuthenticator/README.md
+++ b/KeyCloakAuthenticator/README.md
@@ -29,7 +29,7 @@ In your JupyterHub config file, set the authenticator and configure it:
 ```python
 # Enable the authenticator
 c.JupyterHub.authenticator_class = 'keycloakauthenticator.KeyCloakAuthenticator'
-c.KeyCloakAuthenticator.username_claim = 'preferred_username'
+c.KeyCloakAuthenticator.username_claim = 'cern_upn'
 
 # URL to redirect to after logout is complete with auth provider.
 c.KeyCloakAuthenticator.logout_redirect_url = 'https://cern.ch/swan'

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ c.Spawner.debug = True
 # ================================================
 
 c.JupyterHub.authenticator_class = 'keycloakauthenticator.auth.KeyCloakAuthenticator'
-c.KeyCloakAuthenticator.username_claim = 'preferred_username'
+c.KeyCloakAuthenticator.username_claim = 'cern_upn'
 
 # URL to redirect to after logout is complete with auth provider.
 c.KeyCloakAuthenticator.logout_redirect_url = 'https://cern.ch/swan'


### PR DESCRIPTION
Per https://auth.docs.cern.ch/user-documentation/oidc/config/, it's not guaranteed to be unique. We should use either sub or cern_upn.