### PR TITLE
swanspawner: add unit tests

### DIFF
--- a/SwanSpawner/tests/conftest.py
+++ b/SwanSpawner/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+# swanspawner/__init__.py skips the kubernetes spawner import in dev mode,
+# preventing an in-cluster config load during test collection.
+os.environ.setdefault("SWANHUB_ENV", "dev")

--- a/SwanSpawner/tests/test_gpuinfo.py
+++ b/SwanSpawner/tests/test_gpuinfo.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for AvailableGPUs in _gpuinfo.py.
+
+AvailableGPUs.__init__ calls config.load_incluster_config(), so we bypass it
+by subclassing and skipping __init__, then calling methods directly on instances.
+"""
+
+from threading import Lock
+
+from swanspawner._gpuinfo import AvailableGPUs, _GPUInfo
+
+EVENTS_ROLE = 'swan-events'
+LHCB_ROLE = 'swan-lhcb'
+
+
+class _MockGPUs(AvailableGPUs):
+    """Bypasses __init__ so tests can run without a Kubernetes cluster."""
+
+    def __init__(self, node_to_flavor=None, gpus=None, cordoned=None, lhcb_nodes=None, events_nodes=None):
+        self._events_role = EVENTS_ROLE
+        self._lhcb_role = LHCB_ROLE
+        self._gpus = gpus or {}
+        self._node_to_flavor = node_to_flavor or {}
+        self._cordoned_gpu_nodes = cordoned or []
+        self._lhcb_nodes = lhcb_nodes or set()
+        self._events_nodes = events_nodes or set()
+        self._lock = Lock()
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+# Three-node cluster: one standard, one LHCb-labelled, one events-labelled.
+_NODE_TO_FLAVOR = {
+    ('node-std',    'nvidia.com/gpu'): 'Tesla T4 (16 GB)',
+    ('node-lhcb',   'nvidia.com/gpu'): 'A100 (40 GB)',
+    ('node-events', 'nvidia.com/gpu'): 'Tesla T4 (16 GB)',
+}
+_GPUS = {
+    'Tesla T4 (16 GB)': _GPUInfo('nvidia.com/gpu', 'NVIDIA-T4-16GB',   count=4, free=2),
+    'A100 (40 GB)':     _GPUInfo('nvidia.com/gpu', 'NVIDIA-A100-40GB', count=2, free=0),
+}
+
+
+def _cluster(cordoned=None):
+    return _MockGPUs(
+        node_to_flavor=_NODE_TO_FLAVOR,
+        gpus=_GPUS,
+        cordoned=cordoned or [],
+        lhcb_nodes={'node-lhcb'},
+        events_nodes={'node-events'},
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestGetSimplifiedGpuModel
+# ---------------------------------------------------------------------------
+
+class TestGetSimplifiedGpuModel:
+    def _call(self, product_name):
+        return AvailableGPUs._get_simplified_gpu_model(_MockGPUs(), product_name)
+
+    def test_t4_product_returns_tesla_t4(self):
+        assert self._call('NVIDIA-T4-16GB') == 'Tesla T4'
+
+    def test_a100_product_returns_a100(self):
+        assert self._call('NVIDIA-A100-PCIE-40GB') == 'A100'
+
+    def test_unknown_product_returned_unchanged(self):
+        assert self._call('NVIDIA-H100-SXM5-80GB') == 'NVIDIA-H100-SXM5-80GB'
+
+    def test_t4_substring_anywhere_matches(self):
+        assert self._call('Some-T4-Variant') == 'Tesla T4'
+
+    def test_a100_substring_anywhere_matches(self):
+        assert self._call('A100-SXM4-40GB') == 'A100'
+
+
+# ---------------------------------------------------------------------------
+# TestRoleFlags
+# ---------------------------------------------------------------------------
+
+class TestRoleFlags:
+    def _call(self, roles):
+        return AvailableGPUs._role_flags(_MockGPUs(), roles)
+
+    def test_no_special_role_is_normal(self):
+        is_lhcb, is_events, is_normal = self._call(['some-other-role'])
+        assert not is_lhcb
+        assert not is_events
+        assert is_normal
+
+    def test_empty_roles_is_normal(self):
+        _is_lhcb, _is_events, is_normal = self._call([])
+        assert is_normal
+
+    def test_lhcb_role_detected(self):
+        is_lhcb, is_events, is_normal = self._call([LHCB_ROLE])
+        assert is_lhcb
+        assert not is_events
+        assert not is_normal
+
+    def test_events_role_detected(self):
+        is_lhcb, is_events, is_normal = self._call([EVENTS_ROLE])
+        assert not is_lhcb
+        assert is_events
+        assert not is_normal
+
+    def test_both_roles_not_normal(self):
+        is_lhcb, is_events, is_normal = self._call([LHCB_ROLE, EVENTS_ROLE])
+        assert is_lhcb
+        assert is_events
+        assert not is_normal
+
+
+# ---------------------------------------------------------------------------
+# TestGetAllowedFlavorsForRole
+# ---------------------------------------------------------------------------
+
+class TestGetAllowedFlavorsForRole:
+    def _call(self, mock, is_lhcb, is_events, is_normal):
+        return AvailableGPUs._get_allowed_flavors_for_role(mock, is_lhcb, is_events, is_normal)
+
+    def test_normal_user_sees_only_standard_node(self):
+        flavors = self._call(_cluster(), is_lhcb=False, is_events=False, is_normal=True)
+        assert flavors == {'Tesla T4 (16 GB)'}
+
+    def test_lhcb_user_sees_standard_and_lhcb_nodes(self):
+        flavors = self._call(_cluster(), is_lhcb=True, is_events=False, is_normal=False)
+        assert flavors == {'Tesla T4 (16 GB)', 'A100 (40 GB)'}
+
+    def test_events_user_sees_only_events_node(self):
+        flavors = self._call(_cluster(), is_lhcb=False, is_events=True, is_normal=False)
+        assert flavors == {'Tesla T4 (16 GB)'}
+
+    def test_lhcb_user_does_not_see_events_node(self):
+        # node-events has the events label, so LHCb users must not see it
+        flavors = self._call(_cluster(), is_lhcb=True, is_events=False, is_normal=False)
+        # both Tesla T4 sources: node-std (allowed) and node-events (blocked for lhcb)
+        # A100 from node-lhcb (allowed for lhcb)
+        assert 'A100 (40 GB)' in flavors
+
+    def test_cordoned_node_excluded_for_normal_user(self):
+        mock = _cluster(cordoned=['node-std'])
+        flavors = self._call(mock, is_lhcb=False, is_events=False, is_normal=True)
+        assert flavors == set()
+
+    def test_cordoned_lhcb_node_excluded_for_lhcb_user(self):
+        mock = _cluster(cordoned=['node-lhcb'])
+        flavors = self._call(mock, is_lhcb=True, is_events=False, is_normal=False)
+        assert 'A100 (40 GB)' not in flavors
+
+
+# ---------------------------------------------------------------------------
+# TestGetAvailableGpuFlavours
+# ---------------------------------------------------------------------------
+
+class TestGetAvailableGpuFlavours:
+    def test_normal_user_gets_standard_gpu(self):
+        result = _cluster().get_available_gpu_flavours([])
+        assert list(result.keys()) == ['Tesla T4 (16 GB)']
+
+    def test_lhcb_user_gets_both_gpus(self):
+        result = _cluster().get_available_gpu_flavours([LHCB_ROLE])
+        assert set(result.keys()) == {'Tesla T4 (16 GB)', 'A100 (40 GB)'}
+
+    def test_returned_values_are_gpu_info_objects(self):
+        result = _cluster().get_available_gpu_flavours([])
+        assert isinstance(result['Tesla T4 (16 GB)'], _GPUInfo)
+
+
+# ---------------------------------------------------------------------------
+# TestGetFreeGpuFlavours
+# ---------------------------------------------------------------------------
+
+class TestGetFreeGpuFlavours:
+    def test_normal_user_sees_only_flavours_with_free_count(self):
+        # Tesla T4: free=2, A100: free=0 (but A100 is lhcb-only anyway)
+        result = _cluster().get_free_gpu_flavours([])
+        assert 'Tesla T4 (16 GB)' in result
+
+    def test_lhcb_user_excluded_a100_because_none_free(self):
+        result = _cluster().get_free_gpu_flavours([LHCB_ROLE])
+        assert 'A100 (40 GB)' not in result
+        assert 'Tesla T4 (16 GB)' in result
+
+    def test_no_free_gpus_returns_empty(self):
+        no_free_gpus = {
+            'Tesla T4 (16 GB)': _GPUInfo('nvidia.com/gpu', 'NVIDIA-T4', count=2, free=0),
+        }
+        mock = _MockGPUs(
+            node_to_flavor={('node-std', 'nvidia.com/gpu'): 'Tesla T4 (16 GB)'},
+            gpus=no_free_gpus,
+        )
+        result = mock.get_free_gpu_flavours([])
+        assert result == {}

--- a/SwanSpawner/tests/test_swanspawner.py
+++ b/SwanSpawner/tests/test_swanspawner.py
@@ -5,7 +5,41 @@ Unit tests for swanspawner.py functions
 import os
 
 import pytest
-from swanspawner.swanspawner import get_repo_name_from_options
+from swanspawner.swanspawner import define_SwanSpawner_from, get_repo_name_from_options
+
+_SwanSpawner = define_SwanSpawner_from(object)
+
+
+class _MockLog:
+    def __init__(self):
+        self.warnings = []
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, msg, *args, **kwargs):
+        self.warnings.append(msg)
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+class _MockSpawner:
+    """Minimal stand-in; provides the class-level string constants and a log."""
+
+    rucio_instance = 'rucio'
+    rucio_rse = 'rucioRSE'
+    rucio_rse_mount_path = 'rse_mount_path'
+    rucio_path_begins_at = 'path_begins_at'
+
+    def __init__(self):
+        self.log = _MockLog()
+
+
+def _call_validate_rucio(selection, options):
+    mock = _MockSpawner()
+    result = _SwanSpawner._validate_rucio_options(mock, selection, options)
+    return result, mock.log
 
 
 class TestGetRepoNameFromOptions:
@@ -61,3 +95,107 @@ class TestGetRepoNameFromOptions:
         user_options = {'repository': repo_url}
         result = get_repo_name_from_options(user_options)
         assert result == os.path.join(self.PROJECT_FOLDER, expected_name)
+
+
+# ---------------------------------------------------------------------------
+# TestValidateRucioOptions
+# ---------------------------------------------------------------------------
+
+class TestValidateRucioOptions:
+    def test_none_instance_returns_defaults(self):
+        result, _ = _call_validate_rucio({}, {'rucio': 'none'})
+        assert result == {
+            'rucio': 'none',
+            'rucioRSE': 'none',
+            'rse_mount_path': '',
+            'path_begins_at': '0',
+        }
+
+    def test_missing_rucio_config_in_selection_raises(self):
+        with pytest.raises(ValueError, match="Rucio configuration not found"):
+            _call_validate_rucio({}, {'rucio': 'atlas'})
+
+    def test_unknown_rucio_instance_raises(self):
+        selection = {'rucio': [{'value': 'cms', 'rse_options': []}]}
+        with pytest.raises(ValueError, match="Invalid Rucio instance: atlas"):
+            _call_validate_rucio(selection, {'rucio': 'atlas'})
+
+    def test_invalid_rse_raises(self):
+        selection = {'rucio': [{'value': 'atlas', 'rse_options': [
+            {'value': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': 3},
+        ]}]}
+        with pytest.raises(ValueError, match="Invalid RSE selection"):
+            _call_validate_rucio(selection, {'rucio': 'atlas', 'rucioRSE': 'UNKNOWN_RSE'})
+
+    def test_valid_selection_returns_correct_options(self):
+        selection = {'rucio': [{'value': 'atlas', 'rse_options': [
+            {'value': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': 3},
+        ]}]}
+        result, _ = _call_validate_rucio(
+            selection,
+            {'rucio': 'atlas', 'rucioRSE': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': '3'},
+        )
+        assert result == {
+            'rucio': 'atlas',
+            'rucioRSE': 'ATLAS_CERN',
+            'rse_mount_path': '/eos/atlas',
+            'path_begins_at': '3',
+        }
+
+    def test_missing_rse_mount_path_defaults_to_empty_string(self):
+        selection = {'rucio': [{'value': 'atlas', 'rse_options': [
+            {'value': 'ATLAS_CERN'},
+        ]}]}
+        result, _ = _call_validate_rucio(
+            selection, {'rucio': 'atlas', 'rucioRSE': 'ATLAS_CERN', 'rse_mount_path': ''},
+        )
+        assert result['rse_mount_path'] == ''
+
+    def test_missing_path_begins_at_defaults_to_zero_string(self):
+        selection = {'rucio': [{'value': 'atlas', 'rse_options': [
+            {'value': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas'},
+        ]}]}
+        result, _ = _call_validate_rucio(
+            selection, {'rucio': 'atlas', 'rucioRSE': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': '0'},
+        )
+        assert result['path_begins_at'] == '0'
+
+    def test_path_begins_at_int_in_config_is_returned_as_string(self):
+        selection = {'rucio': [{'value': 'atlas', 'rse_options': [
+            {'value': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': 5},
+        ]}]}
+        result, _ = _call_validate_rucio(
+            selection, {'rucio': 'atlas', 'rucioRSE': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': '5'},
+        )
+        assert result['path_begins_at'] == '5'
+        assert isinstance(result['path_begins_at'], str)
+
+    def test_mount_path_mismatch_logs_warning(self):
+        selection = {'rucio': [{'value': 'atlas', 'rse_options': [
+            {'value': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': 3},
+        ]}]}
+        _, log = _call_validate_rucio(
+            selection,
+            {'rucio': 'atlas', 'rucioRSE': 'ATLAS_CERN', 'rse_mount_path': '/wrong/path', 'path_begins_at': '3'},
+        )
+        assert any('Mount path mismatch' in w for w in log.warnings)
+
+    def test_path_begins_at_mismatch_logs_warning(self):
+        selection = {'rucio': [{'value': 'atlas', 'rse_options': [
+            {'value': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': 3},
+        ]}]}
+        _, log = _call_validate_rucio(
+            selection,
+            {'rucio': 'atlas', 'rucioRSE': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': '99'},
+        )
+        assert any('Path begins at mismatch' in w for w in log.warnings)
+
+    def test_matching_hidden_fields_log_no_warning(self):
+        selection = {'rucio': [{'value': 'atlas', 'rse_options': [
+            {'value': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': 3},
+        ]}]}
+        _, log = _call_validate_rucio(
+            selection,
+            {'rucio': 'atlas', 'rucioRSE': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': '3'},
+        )
+        assert log.warnings == []

--- a/SwanSpawner/tests/test_swanspawner.py
+++ b/SwanSpawner/tests/test_swanspawner.py
@@ -62,6 +62,91 @@ def _call_validate_selection(selection, options):
     return mock
 
 
+# All plain string constants from SwanSpawner — copied to avoid traitlet descriptor issues
+# (options_form_config / stacks_for_customenvs are traitlets, so we can't inherit and must
+# set them as plain instance attributes on a standalone class).
+class _MockSpawnerForForm:
+    software_source = 'software_source'
+    builder = 'builder'
+    builder_version = 'builder_version'
+    repository = 'repository'
+    lcg_rel_field = 'lcg'
+    use_local_packages_field = 'use-local-packages'
+    platform_field = 'platforms'
+    user_script_env_field = 'scriptenv'
+    user_n_cores = 'cores'
+    user_memory = 'memory'
+    gpu = 'gpu'
+    use_jupyterlab_field = 'use-jupyterlab'
+    spark_cluster_field = 'clusters'
+    condor_pool = 'condor'
+    rucio_instance = 'rucio'
+    rucio_rse = 'rucioRSE'
+    rucio_rse_mount_path = 'rse_mount_path'
+    rucio_path_begins_at = 'path_begins_at'
+    file = 'file'
+    user_interface = 'user_interface'
+    customenv_special_type = 'customenv'
+    lcg_special_type = 'lcg'
+
+    _get_selection = _SwanSpawner._get_selection
+    _validate_selection_options = _SwanSpawner._validate_selection_options
+    _popup_error = _SwanSpawner._popup_error
+
+    def __init__(self, config_path, stacks_for_customenvs=None):
+        self.log = _MockLog()
+        self.options_form_config = config_path
+        self.stacks_for_customenvs = stacks_for_customenvs or []
+        self.offload = False
+
+
+# Minimal YAML for tests — no YAML anchors, no rucio section
+_FORM_YAML = """
+lcg_options:
+- type: "selection"
+  lcg:
+    value: "LCG_110_swan"
+  platforms:
+  - value: "x86_64-el9-gcc13-opt"
+  cores:
+  - value: "2"
+  - value: "4"
+  memory:
+  - value: "8"
+  - value: "16"
+  clusters:
+  - value: "none"
+  - value: "spark"
+  condor:
+  - value: "none"
+
+customenv_options:
+- type: "selection"
+  builder:
+    value: "docker"
+  cores:
+  - value: "2"
+  - value: "4"
+  memory:
+  - value: "8"
+  - value: "16"
+- type: "selection"
+  builder:
+    value: "buildkit:2.0"
+  cores:
+  - value: "2"
+  memory:
+  - value: "8"
+"""
+
+
+@pytest.fixture
+def form_config(tmp_path):
+    p = tmp_path / "options_form.yaml"
+    p.write_text(_FORM_YAML)
+    return str(p)
+
+
 class TestGetRepoNameFromOptions:
     """Test suite for get_repo_name_from_options function"""
     PROJECT_FOLDER = "SWAN_projects"
@@ -279,3 +364,94 @@ class TestValidateSelectionOptions:
         }
         with pytest.raises(ValueError):
             _call_validate_selection(selection, {'cores': '999', 'memory': '8'})
+
+
+# ---------------------------------------------------------------------------
+# TestOptionsFromForm
+# ---------------------------------------------------------------------------
+
+class TestOptionsFromForm:
+    @staticmethod
+    def _lcg_formdata(**overrides):
+        data = {
+            'software_source': ['lcg'],
+            'lcg': ['LCG_110_swan'],
+            'platforms': ['x86_64-el9-gcc13-opt'],
+            'scriptenv': ['none'],
+            'condor': ['none'],
+            'cores': ['2'],
+            'memory': ['8'],
+        }
+        data.update(overrides)
+        return data
+
+    @staticmethod
+    def _customenv_formdata(**overrides):
+        data = {
+            'software_source': ['customenv'],
+            'builder': ['docker'],
+            'repository': ['https://github.com/user/repo'],
+            'cores': ['2'],
+            'memory': ['8'],
+        }
+        data.update(overrides)
+        return data
+
+    def test_lcg_common_fields_extracted(self, form_config):
+        mock = _MockSpawnerForForm(form_config)
+        result = _SwanSpawner.options_from_form(mock, self._lcg_formdata())
+        assert result['software_source'] == 'lcg'
+        assert result['lcg'] == 'LCG_110_swan'
+        assert result['platforms'] == 'x86_64-el9-gcc13-opt'
+
+    def test_cores_converted_to_int(self, form_config):
+        mock = _MockSpawnerForForm(form_config)
+        result = _SwanSpawner.options_from_form(mock, self._lcg_formdata())
+        assert result['cores'] == 2
+        assert isinstance(result['cores'], int)
+
+    def test_memory_gets_g_suffix(self, form_config):
+        mock = _MockSpawnerForForm(form_config)
+        result = _SwanSpawner.options_from_form(mock, self._lcg_formdata())
+        assert result['memory'] == '8G'
+
+    def test_offload_false_when_no_cluster(self, form_config):
+        mock = _MockSpawnerForForm(form_config)
+        _SwanSpawner.options_from_form(mock, self._lcg_formdata())
+        assert mock.offload is False
+
+    def test_offload_true_when_cluster_set(self, form_config):
+        mock = _MockSpawnerForForm(form_config)
+        _SwanSpawner.options_from_form(mock, self._lcg_formdata(clusters=['spark']))
+        assert mock.offload is True
+
+    def test_unknown_software_source_raises(self, form_config):
+        mock = _MockSpawnerForForm(form_config)
+        with pytest.raises(ValueError):
+            _SwanSpawner.options_from_form(mock, self._lcg_formdata(software_source=['unknown']))
+
+    def test_customenv_builder_and_repository_extracted(self, form_config):
+        mock = _MockSpawnerForForm(form_config)
+        result = _SwanSpawner.options_from_form(mock, self._customenv_formdata())
+        assert result['builder'] == 'docker'
+        assert result['repository'] == 'https://github.com/user/repo'
+
+    def test_customenv_builder_version_split(self, form_config):
+        mock = _MockSpawnerForForm(form_config)
+        result = _SwanSpawner.options_from_form(mock, self._customenv_formdata(builder=['buildkit:2.0']))
+        assert result['builder'] == 'buildkit'
+        assert result['builder_version'] == '2.0'
+
+    def test_customenv_missing_repository_raises(self, form_config):
+        mock = _MockSpawnerForForm(form_config)
+        formdata = self._customenv_formdata()
+        del formdata['repository']
+        with pytest.raises(ValueError, match="no repository specified"):
+            _SwanSpawner.options_from_form(mock, formdata)
+
+    def test_customenv_missing_repository_ok_for_stack(self, form_config):
+        mock = _MockSpawnerForForm(form_config, stacks_for_customenvs=['docker'])
+        formdata = self._customenv_formdata()
+        del formdata['repository']
+        result = _SwanSpawner.options_from_form(mock, formdata)
+        assert result['builder'] == 'docker'

--- a/SwanSpawner/tests/test_swanspawner.py
+++ b/SwanSpawner/tests/test_swanspawner.py
@@ -455,3 +455,70 @@ class TestOptionsFromForm:
         del formdata['repository']
         result = _SwanSpawner.options_from_form(mock, formdata)
         assert result['builder'] == 'docker'
+
+
+# ---------------------------------------------------------------------------
+# TestGetSelection
+# ---------------------------------------------------------------------------
+
+_LCG_CONFIG = {
+    'lcg_options': [
+        {'type': 'label', 'label': {'value': 'label1', 'text': 'Recommended'}},
+        {
+            'type': 'selection',
+            'lcg': {'value': 'LCG_110_swan'},
+            'cores': [{'value': '2'}, {'value': '4'}],
+        },
+        {
+            'type': 'selection',
+            'lcg': {'value': 'LCG_111_swan'},
+            'cores': [{'value': '2'}],
+        },
+    ],
+    'customenv_options': [
+        {
+            'type': 'selection',
+            'builder': {'value': 'docker'},
+            'cores': [{'value': '2'}],
+        },
+    ],
+}
+
+
+def _call_get_selection(config, options, parent):
+    mock = _MockSpawnerForForm(config_path=None)
+    return _SwanSpawner._get_selection(mock, config, options, parent)
+
+
+class TestGetSelection:
+    def test_lcg_selection_found(self):
+        options = {'software_source': 'lcg', 'lcg': 'LCG_110_swan'}
+        result = _call_get_selection(_LCG_CONFIG, options, 'lcg')
+        assert result['lcg']['value'] == 'LCG_110_swan'
+        assert result['type'] == 'selection'
+
+    def test_second_lcg_entry_found(self):
+        options = {'software_source': 'lcg', 'lcg': 'LCG_111_swan'}
+        result = _call_get_selection(_LCG_CONFIG, options, 'lcg')
+        assert result['lcg']['value'] == 'LCG_111_swan'
+
+    def test_label_entries_are_skipped(self):
+        # The label entry comes first; _get_selection must skip it and find the selection
+        options = {'software_source': 'lcg', 'lcg': 'LCG_110_swan'}
+        result = _call_get_selection(_LCG_CONFIG, options, 'lcg')
+        assert result['type'] == 'selection'
+
+    def test_customenv_selection_found(self):
+        options = {'software_source': 'customenv', 'builder': 'docker'}
+        result = _call_get_selection(_LCG_CONFIG, options, 'builder')
+        assert result['builder']['value'] == 'docker'
+
+    def test_no_matching_value_raises(self):
+        options = {'software_source': 'lcg', 'lcg': 'LCG_999_swan'}
+        with pytest.raises(ValueError, match="Invalid lcg selection"):
+            _call_get_selection(_LCG_CONFIG, options, 'lcg')
+
+    def test_unknown_software_source_raises(self):
+        options = {'software_source': 'unknown', 'lcg': 'LCG_110_swan'}
+        with pytest.raises(KeyError):
+            _call_get_selection(_LCG_CONFIG, options, 'lcg')

--- a/SwanSpawner/tests/test_swanspawner.py
+++ b/SwanSpawner/tests/test_swanspawner.py
@@ -13,6 +13,7 @@ _SwanSpawner = define_SwanSpawner_from(object)
 class _MockLog:
     def __init__(self):
         self.warnings = []
+        self.errors = []
 
     def info(self, *args, **kwargs):
         pass
@@ -20,8 +21,8 @@ class _MockLog:
     def warning(self, msg, *args, **kwargs):
         self.warnings.append(msg)
 
-    def error(self, *args, **kwargs):
-        pass
+    def error(self, msg, *args, **kwargs):
+        self.errors.append(msg)
 
 
 class _MockSpawner:
@@ -40,6 +41,25 @@ def _call_validate_rucio(selection, options):
     mock = _MockSpawner()
     result = _SwanSpawner._validate_rucio_options(mock, selection, options)
     return result, mock.log
+
+
+class _MockSpawnerForSelection(_MockSpawner):
+    """Extends _MockSpawner with tracked _validate_rucio_options and real _popup_error."""
+
+    def __init__(self):
+        super().__init__()
+        self.rucio_calls = []
+
+    def _validate_rucio_options(self, selection, options):
+        self.rucio_calls.append((selection, options))
+
+    _popup_error = _SwanSpawner._popup_error
+
+
+def _call_validate_selection(selection, options):
+    mock = _MockSpawnerForSelection()
+    _SwanSpawner._validate_selection_options(mock, selection, options)
+    return mock
 
 
 class TestGetRepoNameFromOptions:
@@ -199,3 +219,63 @@ class TestValidateRucioOptions:
             {'rucio': 'atlas', 'rucioRSE': 'ATLAS_CERN', 'rse_mount_path': '/eos/atlas', 'path_begins_at': '3'},
         )
         assert log.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# TestValidateSelectionOptions
+# ---------------------------------------------------------------------------
+
+class TestValidateSelectionOptions:
+    def test_empty_selection_passes(self):
+        _call_validate_selection({}, {})
+
+    def test_valid_option_passes(self):
+        selection = {'cores': [{'value': '2'}, {'value': '4'}]}
+        _call_validate_selection(selection, {'cores': '2'})
+
+    def test_invalid_option_raises(self):
+        selection = {'cores': [{'value': '2'}, {'value': '4'}]}
+        with pytest.raises(ValueError, match="Invalid cores selection"):
+            _call_validate_selection(selection, {'cores': '8'})
+
+    def test_missing_option_raises(self):
+        # options.get('cores') → None, not in valid values → _popup_error called.
+        # _popup_error does options[attr] (not .get), so a missing key raises KeyError.
+        selection = {'cores': [{'value': '2'}, {'value': '4'}]}
+        with pytest.raises(KeyError):
+            _call_validate_selection(selection, {})
+
+    def test_non_list_attr_is_skipped(self):
+        # 'type' is a string, 'lcg' is a dict — neither triggers validation
+        selection = {'type': 'selection', 'lcg': {'value': 'LCG_110', 'text': '110'}}
+        _call_validate_selection(selection, {})
+
+    def test_rucio_attr_delegates_to_validate_rucio(self):
+        selection = {'rucio': [{'value': 'atlas', 'rse_options': []}]}
+        options = {'rucio': 'atlas'}
+        mock = _call_validate_selection(selection, options)
+        assert len(mock.rucio_calls) == 1
+        assert mock.rucio_calls[0] == (selection, options)
+
+    def test_rucio_sub_attrs_are_skipped(self):
+        selection = {
+            'rucioRSE': 'ATLAS_CERN',
+            'rse_mount_path': '/eos/atlas',
+            'path_begins_at': '3',
+        }
+        _call_validate_selection(selection, {})
+
+    def test_multiple_valid_options_all_pass(self):
+        selection = {
+            'cores': [{'value': '2'}, {'value': '4'}],
+            'memory': [{'value': '8'}, {'value': '16'}],
+        }
+        _call_validate_selection(selection, {'cores': '2', 'memory': '8'})
+
+    def test_first_invalid_option_raises(self):
+        selection = {
+            'cores': [{'value': '2'}, {'value': '4'}],
+            'memory': [{'value': '8'}, {'value': '16'}],
+        }
+        with pytest.raises(ValueError):
+            _call_validate_selection(selection, {'cores': '999', 'memory': '8'})


### PR DESCRIPTION
Adds unit tests for the validation of selection options, ruco options, options from form and the gpu info functions