### PR TITLE
KeyCloakAuthenticator: fix mutable default argument in _decode_token

### DIFF
--- a/KeyCloakAuthenticator/keycloakauthenticator/auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/auth.py
@@ -210,7 +210,9 @@ class KeyCloakAuthenticator(GenericOAuthenticator):
         return not self._allowed_roles or \
             (self._allowed_roles & user_roles)
 
-    def _decode_token(self, token, options={}):
+    def _decode_token(self, token, options=None):
+        if options is None:
+            options = {}
         if not self.config.check_signature:
             options.update({"verify_signature": False})
         if not self.verify_aud:

--- a/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
+++ b/KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py
@@ -359,6 +359,24 @@ class TestKeyCloakAuthenticator:
             token = _get_mock_token(private_key, "test-token")
             assert authenticator._decode_token(token, options={}) is not None
 
+        def test_does_not_leak_disabled_signature_check_across_calls(self, authenticator, key_pair):
+            # `options` used to default to a mutable `{}`, shared by every call
+            # that doesn't pass one explicitly. The first call below disables
+            # signature verification, which sets "verify_signature": False in
+            # that shared dict; a later call - with signature checking enabled
+            # again, and again relying on the default - must not inherit it.
+            public_key, _ = key_pair
+            self._setup(authenticator, public_key)
+            _, other_private_key = _generate_mock_public_private_key_pair()
+            token_wrong_sig = _get_mock_token(other_private_key, "test-token")
+
+            authenticator.config.check_signature = False
+            assert authenticator._decode_token(token_wrong_sig) is not None
+
+            authenticator.config.check_signature = True
+            with pytest.raises(jwt.exceptions.InvalidSignatureError):
+                authenticator._decode_token(token_wrong_sig)
+
     class TestExchangeTokens:
         async def test_empty_response_body_skips_service(self, authenticator, monkeypatch):
             authenticator.exchange_tokens = ["service-a"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "KeyCloakAuthenticator/keycloakauthenticator/auth.py" = [
-    "B006",   # mutable-argument-default
     "RUF006", # asyncio-dangling-task
 ]
 "KeyCloakAuthenticator/keycloakauthenticator/__init__.py" = [


### PR DESCRIPTION
## The bug

`_decode_token` used a mutable default argument: `def _decode_token(self, token, options={})`. Every call that relies on the default reuses the *same* dict object across calls.

When signature checking is disabled (`check_signature = False`), the method does `options.update({"verify_signature": False})`. Because `options` is the shared default dict, this mutation persists across calls, so a later call made with `check_signature = True` (also relying on the default) would silently inherit `verify_signature: False` from a previous call, disabling signature verification without anyone intending that.

This is a security-relevant bug: it can allow a JWT with an invalid signature to be accepted after any earlier call happened to run with signature checking disabled.

## The fix

- `KeyCloakAuthenticator/keycloakauthenticator/auth.py`: change the default to `options=None` and create a fresh `{}` inside the function body when `options is None`, so each call gets its own dict.
- `KeyCloakAuthenticator/keycloakauthenticator/tests/test_auth.py`: add a regression test, `test_does_not_leak_disabled_signature_check_across_calls`, that reproduces the leak — it fails on the old code (`DID NOT RAISE InvalidSignatureError`) and passes with the fix.
- `pyproject.toml`: remove the now-unneeded `B006` (mutable-argument-default) per-file ruff ignore for `auth.py`, as requested in the issue.

Fixes #300.

## Testing

Ran locally, matching the project's CI exactly:
- `uv run --no-project ruff check .` → All checks passed!
- `SWANHUB_ENV=dev python -m pytest -q` → 68 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBjMRnWYjrHtxP7YtwcxxZ